### PR TITLE
Remove dependency on the TokenCache for accessing the Graph API

### DIFF
--- a/module/functions/azure/aad/Assert-RequiredResourceAccessContains.ps1
+++ b/module/functions/azure/aad/Assert-RequiredResourceAccessContains.ps1
@@ -60,14 +60,14 @@ function Assert-RequiredResourceAccessContains
         $graphApiAppUri = (Get-AzureAdGraphApiAppUri $app)
 
         $patchRequiredResourceAccess = @{requiredResourceAccess=$requiredResourceAccess}
-        $patchRequiredResourceAccessJson = ConvertTo-Json $patchRequiredResourceAccess -Depth 4
-        
-        $response = Invoke-WebRequest -Uri $graphApiAppUri `
-                                      -Method "PATCH" `
-                                      -Headers (Get-AzureAdGraphHeaders) `
-                                      -Body $patchRequiredResourceAccessJson
 
-        $response = Invoke-WebRequest -Uri $graphApiAppUri -Headers (Get-AzureAdGraphHeaders)
+        $response = Invoke-AzCliRestCommand -Uri $graphApiAppUri `
+                                            -Method 'PATCH' `
+                                            -Body $patchRequiredResourceAccess
+                                            -Headers @{ "content-type" = "application/json" }
+
+        $response = Invoke-AzCliRestCommand -Uri $graphApiAppUri `
+                                            -Headers @{ "content-type" = "application/json" }
 
         $appManifest = ConvertFrom-Json $Response.Content
 

--- a/module/functions/azure/aad/Assert-RequiredResourceAccessContains.ps1
+++ b/module/functions/azure/aad/Assert-RequiredResourceAccessContains.ps1
@@ -37,7 +37,7 @@ function Assert-RequiredResourceAccessContains
     )
 
     $madeChange = $false
-    [array]$requiredResourceAccess = (Get-AzureADApplicationManifest $app).requiredResourceAccess
+    [array]$requiredResourceAccess = (Get-AzureADApplicationManifest $App).requiredResourceAccess
     $resourceEntry = $requiredResourceAccess | Where-Object {$_.resourceAppId -eq $ResourceId }
     if (-not $resourceEntry) {
         $madeChange = $true
@@ -57,7 +57,7 @@ function Assert-RequiredResourceAccessContains
     }
 
     if ($madeChange) {
-        $graphApiAppUri = (Get-AzureAdGraphApiAppUri $app)
+        $graphApiAppUri = (Get-AzureAdGraphApiAppUri $App)
 
         $patchRequiredResourceAccess = @{requiredResourceAccess=$requiredResourceAccess}
 
@@ -66,10 +66,8 @@ function Assert-RequiredResourceAccessContains
                                             -Body $patchRequiredResourceAccess
                                             -Headers @{ "content-type" = "application/json" }
 
-        $response = Invoke-AzCliRestCommand -Uri $graphApiAppUri `
-                                            -Headers @{ "content-type" = "application/json" }
-
-        $appManifest = ConvertFrom-Json $Response.Content
+        $appManifest = Invoke-AzCliRestCommand -Uri $graphApiAppUri `
+                                               -Headers @{ "content-type" = "application/json" }
 
         return $appManifest
     }

--- a/module/functions/azure/aad/Get-AzureAdApplicationManifest.ps1
+++ b/module/functions/azure/aad/Get-AzureAdApplicationManifest.ps1
@@ -24,9 +24,8 @@ function Get-AzureADApplicationManifest
         [Microsoft.Azure.Commands.ActiveDirectory.PSADApplication] $App
     )
 
-    $response = Invoke-AzCliRestCommand -Uri (Get-AzureAdGraphApiAppUri $App) `
+    $manifest = Invoke-AzCliRestCommand -Uri (Get-AzureAdGraphApiAppUri $App) `
                                         -Headers @{ "content-type" = "application/json" }
-    $manifest = ConvertFrom-Json $response.Content
 
     return $manifest
 }

--- a/module/functions/azure/aad/Get-AzureAdApplicationManifest.ps1
+++ b/module/functions/azure/aad/Get-AzureAdApplicationManifest.ps1
@@ -24,7 +24,8 @@ function Get-AzureADApplicationManifest
         [Microsoft.Azure.Commands.ActiveDirectory.PSADApplication] $App
     )
 
-    $response = Invoke-WebRequest -Uri (Get-AzureAdGraphApiAppUri $App) -Headers (Get-AzureAdGraphHeaders)
+    $response = Invoke-AzCliRestCommand -Uri (Get-AzureAdGraphApiAppUri $App) `
+                                        -Headers @{ "content-type" = "application/json" }
     $manifest = ConvertFrom-Json $response.Content
 
     return $manifest

--- a/module/functions/azure/aad/Test-AzureGraphAccess.ps1
+++ b/module/functions/azure/aad/Test-AzureGraphAccess.ps1
@@ -19,13 +19,18 @@ function Test-AzureGraphAccess
     (
     )
 
-    # perform an arbitrary AAD operation to force getting a graph api token, in case don't yet have one
-    Get-AzADApplication -ApplicationId (New-Guid).Guid -ErrorAction SilentlyContinue | Out-Null
-  
-    if ( !(Get-AzureAdGraphToken) ) {
-        return $False
+    # perform an arbitrary AAD operation to see if we have read access to the graph API
+    try {
+        Get-AzADApplication -ApplicationId (New-Guid).Guid -ErrorAction Stop
     }
-    else {
-        return $True
+    catch {
+        if ($_.Exception.Message -match "Insufficient privileges") {
+            return $False
+        }
+        else {
+            throw $_
+        }
     }
+
+    return $True
 }

--- a/module/functions/azure/azcli/Invoke-AzCliRestCommand.ps1
+++ b/module/functions/azure/azcli/Invoke-AzCliRestCommand.ps1
@@ -33,12 +33,14 @@ function Invoke-AzCliRestCommand
         [Parameter(Mandatory=$true)]
         [string] $Uri,
         
-        [Parameter(Mandatory=$true)]
+        [Parameter()]
         [ValidateSet("DELETE", "GET", "PATCH", "POST", "PUT")]
-        [string] $Method,
+        [string] $Method = "GET",
         
+        [Parameter()]
         [hashtable] $Body,
         
+        [Parameter()]
         [hashtable] $Headers
     )
 

--- a/module/functions/azure/azcli/Invoke-AzCliRestCommand.ps1
+++ b/module/functions/azure/azcli/Invoke-AzCliRestCommand.ps1
@@ -1,0 +1,60 @@
+# <copyright file="Invoke-AzCliRestCommand.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+<#
+.SYNOPSIS
+Provides a wrapper around the 'az rest' command included with the azure-cli.
+
+.DESCRIPTION
+Provides a wrapper around the 'az rest' command included with the azure-cli, handling all the necessary JSON escaping.
+
+.PARAMETER Uri
+The Uri of the request to be invoked.
+
+.PARAMETER Method
+The REST method of the request to be invoked.
+
+.PARAMETER Body
+The body of the request to be invoked.
+
+.PARAMETER Headers
+The HTTP headers required by the request to be invoked.
+
+.OUTPUTS
+The JSON output from the underlying azure-cli command, in hashtable format.
+
+#>
+
+function Invoke-AzCliRestCommand
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [string] $Uri,
+        
+        [Parameter(Mandatory=$true)]
+        [ValidateSet("DELETE", "GET", "PATCH", "POST", "PUT")]
+        [string] $Method,
+        
+        [hashtable] $Body,
+        
+        [hashtable] $Headers
+    )
+
+    if (@("GET", "DELETE") -contains $Method) {
+        $uriEscaped = $Uri.Replace("'", "''")
+
+        $response = Invoke-AzCli -Command "rest --uri '$uriEscaped' --method '$Method'" -AsJson
+
+        return $response
+    }
+    else {
+        $bodyAsEscapedJsonString = (ConvertTo-Json $Body -Depth 30 -Compress).replace('"', '\"').replace(':\', ': \').replace("'", "''")
+        $headersAsEscapedJsonString = (ConvertTo-Json $Headers -Compress).replace('"', '\"').replace(':\', ': \').replace("'", "''")
+
+        $response = Invoke-AzCli -Command "rest --uri '$Uri' --method '$Method' --body '$bodyAsEscapedJsonString' --headers '$headersAsEscapedJsonString'" -AsJson
+
+        return $response
+    }
+}


### PR DESCRIPTION
Versions of the `Az.Accounts` module >1.9.5 no longer populate AzContext's `TokenCache` property, which we relied on when performing Graph API operations. (ref: https://github.com/Azure/azure-powershell/issues/13337)

This change alters the way we test for graph API access and uses the azure-cli `az rest` command to handle authenticating and calling the Graph API.

A future Az PowerShell release may extend the `Invoke-AzRestMethod` cmdlet to support more endpoints than just AzureRM, which should allow us to switch back to a pure PowerShell solution.