### PR TITLE
Fixes issue with AzureAD application deployments and other minor improvements

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -120,7 +120,10 @@ jobs:
     - name: Install GitVersion
       run: |
         dotnet tool install -g GitVersion.Tool --version 5.2.4
-        echo "::add-path::/github/home/.dotnet/tools"    
+        echo "::add-path::/github/home/.dotnet/tools"
+      # temporary workaround
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true  
     - name: Run GitVersion
       id: run_gitversion
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,9 @@ jobs:
       run: |
         dotnet tool install -g GitVersion.Tool --version 5.2.4
         echo "::add-path::/github/home/.dotnet/tools"
+      # temporary workaround
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - name: Run GitVersion
       id: run_gitversion
       run: |

--- a/.github/workflows/publish_to_psgallery.yml
+++ b/.github/workflows/publish_to_psgallery.yml
@@ -23,7 +23,10 @@ jobs:
     - name: Install GitVersion
       run: |
         dotnet tool install -g GitVersion.Tool --version 5.2.4
-        echo "::add-path::/github/home/.dotnet/tools"    
+        echo "::add-path::/github/home/.dotnet/tools"
+      # temporary workaround
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - name: Run GitVersion
       id: run_gitversion
       run: |

--- a/module/arm-artifacts/shared-templates/synapse-workspace.json
+++ b/module/arm-artifacts/shared-templates/synapse-workspace.json
@@ -129,7 +129,7 @@
           "type": "Microsoft.Synapse/workspaces/bigDataPools",
           "apiVersion": "2019-06-01-preview",
           "name": "[concat(parameters('workspaceName'), '/SmallSparkPool')]",
-          "location": "northeurope",
+          "location": "[parameters('location')]",
           "dependsOn": [
               "[concat('Microsoft.Synapse/workspaces/', parameters('workspaceName'))]"
           ],

--- a/module/arm-artifacts/shared-templates/synapse-workspace.json
+++ b/module/arm-artifacts/shared-templates/synapse-workspace.json
@@ -103,11 +103,24 @@
     },
     "defaultSparkPoolNodeSize": {
       "type": "string",
+      "allowedValues": [
+				"Large",
+				"Medium",
+        "None",
+        "Small",
+        "XLarge",
+        "XXLarge",
+        "XXXLarge"
+			],
       "defaultValue": "Small"
     },
     "defaultSparkPoolNodeSizeFamily": {
       "type": "string",
-      "defaultValue": "Small"
+      "allowedValues": [
+				"MemoryOptimized",
+				"None"
+			],
+      "defaultValue": "MemoryOptimized"
     },
     "defaultSparkPoolNodeCount": {
       "type": "int",
@@ -166,10 +179,10 @@
       },
       "resources": [
         {
-          "type": "Microsoft.Synapse/workspaces/bigDataPools",
+          "type": "bigDataPools",
           "condition": "[not(equals(parameters('defaultSparkPoolName'), 'false'))]",
           "apiVersion": "2019-06-01-preview",
-          "name": "[concat(parameters('workspaceName'), '/', parameters('defaultSparkPoolName'))]",
+          "name": "[parameters('defaultSparkPoolName')]",
           "location": "[parameters('location')]",
           "dependsOn": [
               "[concat('Microsoft.Synapse/workspaces/', parameters('workspaceName'))]"
@@ -190,9 +203,11 @@
             },
             "isComputeIsolationEnabled": false,
             "sessionLevelPackagesEnabled": false
-          }
+          },
+          "tags": "[parameters('tagValues')]"
         },
         {
+          "type": "firewallRules",
           "condition": "[parameters('allowAllConnections')]",
           "apiVersion": "2019-06-01-preview",
           "dependsOn": [
@@ -204,9 +219,10 @@
             "startIpAddress": "0.0.0.0",
             "endIpAddress": "255.255.255.255"
           },
-          "type": "firewallRules"
+          "tags": "[parameters('tagValues')]"
         },
         {
+          "type": "managedIdentitySqlControlSettings",
           "apiVersion": "2019-06-01-preview",
           "dependsOn": [
             "[concat('Microsoft.Synapse/workspaces/', parameters('workspaceName'))]"
@@ -218,7 +234,7 @@
               "desiredState": "[parameters('grantWorkspaceIdentityControlForSql')]"
             }
           },
-          "type": "managedIdentitySqlControlSettings"
+          "tags": "[parameters('tagValues')]"
         },
         {
           "type": "administrators",
@@ -233,14 +249,15 @@
           },
           "dependsOn": [
               "[concat('Microsoft.Synapse/workspaces/', parameters('workspaceName'))]"
-          ]
+          ],
+          "tags": "[parameters('tagValues')]"
         }
       ],
       "dependsOn": [
         "[variables('defaultDataLakeStorageDeployName')]",
         "[concat('Microsoft.Resources/deployments/', parameters('defaultDataLakeStorageFilesystemName'))]"
       ],
-      "tags": "[parameters('tagValues')]"
+      "tags": "[variables('tags')]"
     },
     {
       "condition": "[parameters('setWorkspaceIdentityRbacOnStorageAccount')]",

--- a/module/arm-artifacts/shared-templates/synapse-workspace.json
+++ b/module/arm-artifacts/shared-templates/synapse-workspace.json
@@ -95,7 +95,7 @@
     },
     "defaultSparkPoolName": {
       "type": "string",
-      "defaultValue": "false"
+      "defaultValue": ""
     },
     "defaultSparkPoolVersion": {
       "type": "string",
@@ -180,7 +180,7 @@
       "resources": [
         {
           "type": "bigDataPools",
-          "condition": "[not(equals(parameters('defaultSparkPoolName'), 'false'))]",
+          "condition": "[not(equals(parameters('defaultSparkPoolName'), ''))]",
           "apiVersion": "2019-06-01-preview",
           "name": "[parameters('defaultSparkPoolName')]",
           "location": "[parameters('location')]",

--- a/module/arm-artifacts/shared-templates/synapse-workspace.json
+++ b/module/arm-artifacts/shared-templates/synapse-workspace.json
@@ -126,6 +126,32 @@
       },
       "resources": [
         {
+          "type": "Microsoft.Synapse/workspaces/bigDataPools",
+          "apiVersion": "2019-06-01-preview",
+          "name": "[concat(parameters('workspaceName'), '/SmallSparkPool')]",
+          "location": "northeurope",
+          "dependsOn": [
+              "[concat('Microsoft.Synapse/workspaces/', parameters('workspaceName'))]"
+          ],
+          "properties": {
+            "sparkVersion": "2.4",
+            "nodeCount": 3,
+            "nodeSize": "Small",
+            "nodeSizeFamily": "MemoryOptimized",
+            "autoScale": {
+              "enabled": false,
+              "minNodeCount": 0,
+              "maxNodeCount": 0
+            },
+            "autoPause": {
+              "enabled": true,
+              "delayInMinutes": 15
+            },
+            "isComputeIsolationEnabled": false,
+            "sessionLevelPackagesEnabled": false,
+          }
+        },
+        {
           "condition": "[parameters('allowAllConnections')]",
           "apiVersion": "2019-06-01-preview",
           "dependsOn": [

--- a/module/arm-artifacts/shared-templates/synapse-workspace.json
+++ b/module/arm-artifacts/shared-templates/synapse-workspace.json
@@ -92,6 +92,46 @@
     "setSbdcRbacOnStorageAccount": {
       "type": "bool",
       "defaultValue": false
+    },
+    "defaultSparkPoolName": {
+      "type": "string",
+      "defaultValue": "false"
+    },
+    "defaultSparkPoolVersion": {
+      "type": "string",
+      "defaultValue": "2.4"
+    },
+    "defaultSparkPoolNodeSize": {
+      "type": "string",
+      "defaultValue": "Small"
+    },
+    "defaultSparkPoolNodeSizeFamily": {
+      "type": "string",
+      "defaultValue": "Small"
+    },
+    "defaultSparkPoolNodeCount": {
+      "type": "int",
+      "defaultValue": 3
+    },
+    "defaultSparkPoolAutoScaleEnabled": {
+      "type": "bool",
+      "defaultValue": false
+    },
+    "defaultSparkPoolAutoScaleMinNodes": {
+      "type": "int",
+      "defaultValue": 0
+    },
+    "defaultSparkPoolAutoScaleMaxNodes": {
+      "type": "int",
+      "defaultValue": 0
+    },
+    "defaultSparkPoolAutoPauseEnabled": {
+      "type": "bool",
+      "defaultValue": true
+    },
+    "defaultSparkPoolAutoPauseDelayMinutes": {
+      "type": "int",
+      "defaultValue": 15
     }
   },
   "variables": {
@@ -127,28 +167,29 @@
       "resources": [
         {
           "type": "Microsoft.Synapse/workspaces/bigDataPools",
+          "condition": "[not(equals(parameters('defaultSparkPoolName'), 'false'))]",
           "apiVersion": "2019-06-01-preview",
-          "name": "[concat(parameters('workspaceName'), '/SmallSparkPool')]",
+          "name": "[concat(parameters('workspaceName'), '/', parameters('defaultSparkPoolName'))]",
           "location": "[parameters('location')]",
           "dependsOn": [
               "[concat('Microsoft.Synapse/workspaces/', parameters('workspaceName'))]"
           ],
           "properties": {
-            "sparkVersion": "2.4",
-            "nodeCount": 3,
-            "nodeSize": "Small",
-            "nodeSizeFamily": "MemoryOptimized",
+            "sparkVersion": "[parameters('defaultSparkPoolVersion')]",
+            "nodeCount": "[parameters('defaultSparkPoolNodeCount')]",
+            "nodeSize": "[parameters('defaultSparkPoolNodeSize')]",
+            "nodeSizeFamily": "[parameters('defaultSparkPoolNodeSizeFamily')]",
             "autoScale": {
-              "enabled": false,
-              "minNodeCount": 0,
-              "maxNodeCount": 0
+              "enabled": "[parameters('defaultSparkPoolAutoScaleEnabled')]",
+              "minNodeCount": "[parameters('defaultSparkPoolAutoScaleMinNodes')]",
+              "maxNodeCount": "[parameters('defaultSparkPoolAutoScaleMaxNodes')]"
             },
             "autoPause": {
-              "enabled": true,
-              "delayInMinutes": 15
+              "enabled": "[parameters('defaultSparkPoolAutoPauseEnabled')]",
+              "delayInMinutes": "[parameters('defaultSparkPoolAutoPauseDelayMinutes')]"
             },
             "isComputeIsolationEnabled": false,
-            "sessionLevelPackagesEnabled": false,
+            "sessionLevelPackagesEnabled": false
           }
         },
         {

--- a/module/functions/Merge-Hashtables.Tests.ps1
+++ b/module/functions/Merge-Hashtables.Tests.ps1
@@ -36,4 +36,20 @@ Describe 'Merge-Hashtable tests' {
             $res['Foo'] | Should -Be 'notfoo'
         }
     }
+
+    Context 'Merging without pipeline input' {
+        It 'Returns a merged hashtable' {
+            $res = Merge-HashTables $h1 $h2 $h3
+            $res.Keys.Count | Should -Be 3
+            $res['Foo'] | Should -Be 'notfoo'
+        }
+    }
+
+    Context 'Merging without pipeline input with array arg' {
+        It 'Returns a merged hashtable' {
+            $res = Merge-HashTables @($h1,$h2,$h3)
+            $res.Keys.Count | Should -Be 3
+            $res['Foo'] | Should -Be 'notfoo'
+        }
+    }
 }

--- a/module/functions/Merge-Hashtables.ps1
+++ b/module/functions/Merge-Hashtables.ps1
@@ -33,7 +33,14 @@ Hashtable
 function Merge-Hashtables
 {
     $output = @{}
-    foreach ($hashtable in ($Input + $args)) {
+
+    # process input
+    [hashtable[]] $hashtables = @()
+    if ($Input) { $hashtables += $Input }
+    foreach ($h in $args) { $hashtables += $h }
+
+    # perform merge
+    foreach ($hashtable in $hashtables) {
         if ($hashtable -is [Hashtable]) {
             foreach ($key in $hashtable.Keys) {
                 $output.$key = $hashtable.$key

--- a/module/functions/azure/aad/Assert-RequiredResourceAccessContains.ps1
+++ b/module/functions/azure/aad/Assert-RequiredResourceAccessContains.ps1
@@ -64,10 +64,8 @@ function Assert-RequiredResourceAccessContains
         $response = Invoke-AzCliRestCommand -Uri $graphApiAppUri `
                                             -Method 'PATCH' `
                                             -Body $patchRequiredResourceAccess
-                                            -Headers @{ "content-type" = "application/json" }
 
-        $appManifest = Invoke-AzCliRestCommand -Uri $graphApiAppUri `
-                                               -Headers @{ "content-type" = "application/json" }
+        $appManifest = Invoke-AzCliRestCommand -Uri $graphApiAppUri
 
         return $appManifest
     }

--- a/module/functions/azure/aad/Get-AzureAdApplicationManifest.ps1
+++ b/module/functions/azure/aad/Get-AzureAdApplicationManifest.ps1
@@ -24,8 +24,7 @@ function Get-AzureADApplicationManifest
         [Microsoft.Azure.Commands.ActiveDirectory.PSADApplication] $App
     )
 
-    $manifest = Invoke-AzCliRestCommand -Uri (Get-AzureAdGraphApiAppUri $App) `
-                                        -Headers @{ "content-type" = "application/json" }
+    $manifest = Invoke-AzCliRestCommand -Uri (Get-AzureAdGraphApiAppUri $App)
 
     return $manifest
 }

--- a/module/functions/azure/azcli/Invoke-AzCliRestCommand.ps1
+++ b/module/functions/azure/azcli/Invoke-AzCliRestCommand.ps1
@@ -19,7 +19,9 @@ The REST method of the request to be invoked.
 The body of the request to be invoked.
 
 .PARAMETER Headers
-The HTTP headers required by the request to be invoked.
+The HTTP headers required by the request to be invoked.  The "Content-Type" header will be automatically added if missing:
+
+@{ "Content-Type" = "application/json" }
 
 .OUTPUTS
 The JSON output from the underlying azure-cli command, in hashtable format.
@@ -43,6 +45,11 @@ function Invoke-AzCliRestCommand
         [Parameter()]
         [hashtable] $Headers
     )
+
+    # Ensure we always have the 'Content-Type' header
+    if ( !$Headers.ContainsKey("Content-Type") ) {
+        $Headers += @{ "Content-Type" = "application/json" }
+    }
 
     if (@("GET", "DELETE") -contains $Method) {
         $uriEscaped = $Uri.Replace("'", "''")

--- a/module/functions/azure/azcli/Invoke-AzCliRestCommand.ps1
+++ b/module/functions/azure/azcli/Invoke-AzCliRestCommand.ps1
@@ -43,7 +43,7 @@ function Invoke-AzCliRestCommand
         [hashtable] $Body,
         
         [Parameter()]
-        [hashtable] $Headers
+        [hashtable] $Headers = @{}
     )
 
     # Ensure we always have the 'Content-Type' header


### PR DESCRIPTION
Updated Cmdlets:
* `Invoke-CorvusAzCli`: Logging of errors improved
* `Invoke-CorvusAzCliRestCommand`: The `Content-Type` header is now added by default to make calls to it more terse
* `Merge-CorvusHashtables`: Updated to support passing an array of hashtables to be merged
* `Assert-CorvusRequiredResourceAccessContains`: Fixed major bug and now uses more terse `Invoke-CorvusAzCliRestCommand` syntax
* `Get-CorvusAzureADApplicationManifest`: Updated to use more terse `Invoke-CorvusAzCliRestCommand` syntax

Update ARM templates:
* `synapse-workspace.json`: Now includes a default Spark Pool and fixes issue with child resources not being tagged
