### PR TITLE
Updates for adding key-vault support to synapse scenario

### DIFF
--- a/module/arm-artifacts/shared-templates/key-vault.json
+++ b/module/arm-artifacts/shared-templates/key-vault.json
@@ -52,11 +52,18 @@
       "metadata": {
         "description": "Flag indicating whether diagnostics are enabled or not"
       }
+    },
+    "tagValues": {
+      "type": "object",
+      "defaultValue": {}
     }
   },
   "variables": {
     "defaultApiVersion": "2015-06-15",
-    "location": "[resourceGroup().location]"
+    "location": "[resourceGroup().location]",
+    "keyVaultLocalTags": {
+      "displayName": "KeyVault"
+    }
   },
   "resources": [
     {
@@ -64,9 +71,7 @@
       "name": "[parameters('keyVaultName')]",
       "apiVersion": "2015-06-01",
       "location": "[resourceGroup().location]",
-      "tags": {
-        "displayName": "KeyVault"
-      },
+      "tags": "[union(parameters('tagValues'), variables('keyVaultLocalTags'))]",
       "properties": {
         "tenantId": "[parameters('tenantId')]",
         "accessPolicies": "[parameters('accessPolicies')]",

--- a/module/arm-artifacts/shared-templates/synapse-workspace.json
+++ b/module/arm-artifacts/shared-templates/synapse-workspace.json
@@ -80,15 +80,15 @@
       "type": "bool"
     },
     "datalakeContributorGroupId": {
-			"type": "string",
-			"defaultValue": ""
-		},
+      "type": "string",
+      "defaultValue": ""
+    },
     "sqlAdministratorPrincipalName": {
-			"type": "string"
-		},
+      "type": "string"
+    },
     "sqlAdministratorPrincipalId": {
-			"type": "string"
-		},
+      "type": "string"
+    },
     "setSbdcRbacOnStorageAccount": {
       "type": "bool",
       "defaultValue": false
@@ -104,22 +104,22 @@
     "defaultSparkPoolNodeSize": {
       "type": "string",
       "allowedValues": [
-				"Large",
-				"Medium",
+        "Large",
+        "Medium",
         "None",
         "Small",
         "XLarge",
         "XXLarge",
         "XXXLarge"
-			],
+      ],
       "defaultValue": "Small"
     },
     "defaultSparkPoolNodeSizeFamily": {
       "type": "string",
       "allowedValues": [
-				"MemoryOptimized",
-				"None"
-			],
+        "MemoryOptimized",
+        "None"
+      ],
       "defaultValue": "MemoryOptimized"
     },
     "defaultSparkPoolNodeCount": {
@@ -153,7 +153,7 @@
     "defaultDataLakeStorageAccountUrl": "[concat('https://', parameters('defaultDataLakeStorageAccountName'), '.dfs.core.windows.net')]",
     "defaultDataLakeStorageDeployName": "[concat(deployment().name, '-defsa')]",
     "synapseManagedIdentityRoleAssignmentId": "[guid(concat(resourceGroup().id, '/', variables('storageBlobDataContributorRoleID'), '/', parameters('workspaceName'), '/', 'synapse-managed-identity'))]",
-		"datalakeContributorRoleAssignmentId": "[guid(concat(resourceGroup().id, '/', variables('storageBlobDataContributorRoleID'), '/', parameters('datalakeContributorGroupId'), '/', 'datalake-contributor-group'))]",
+    "datalakeContributorRoleAssignmentId": "[guid(concat(resourceGroup().id, '/', variables('storageBlobDataContributorRoleID'), '/', parameters('datalakeContributorGroupId'), '/', 'datalake-contributor-group'))]",
     "defaultDataLakeStorageResourceReaderRoleAssignmentId": "[guid(concat(resourceGroup().id, '/', variables('readerRoleID'), '/', parameters('datalakeContributorGroupId'), '/', 'datalake-contributor-group'))]",
     "defaultSparkPoolNameSafe": "[if(equals(parameters('defaultSparkPoolName'),''), 'not-required', parameters('defaultSparkPoolName'))]",
     "localTags": {
@@ -186,7 +186,7 @@
           "name": "[variables('defaultSparkPoolNameSafe')]",
           "location": "[parameters('location')]",
           "dependsOn": [
-              "[concat('Microsoft.Synapse/workspaces/', parameters('workspaceName'))]"
+            "[concat('Microsoft.Synapse/workspaces/', parameters('workspaceName'))]"
           ],
           "properties": {
             "sparkVersion": "[parameters('defaultSparkPoolVersion')]",
@@ -243,13 +243,13 @@
           "apiVersion": "2019-06-01-preview",
           "location": "[parameters('location')]",
           "properties": {
-              "administratorType": "ActiveDirectory",
-              "login": "[parameters('sqlAdministratorPrincipalName')]",
-              "sid": "[parameters('sqlAdministratorPrincipalId')]",
-              "tenantId": "[subscription().tenantId]"
+            "administratorType": "ActiveDirectory",
+            "login": "[parameters('sqlAdministratorPrincipalName')]",
+            "sid": "[parameters('sqlAdministratorPrincipalId')]",
+            "tenantId": "[subscription().tenantId]"
           },
           "dependsOn": [
-              "[concat('Microsoft.Synapse/workspaces/', parameters('workspaceName'))]"
+            "[concat('Microsoft.Synapse/workspaces/', parameters('workspaceName'))]"
           ],
           "tags": "[parameters('tagValues')]"
         }
@@ -382,6 +382,10 @@
     "synapseManagedIdentity": {
       "type": "string",
       "value": "[reference(concat('Microsoft.Synapse/workspaces/', parameters('workspaceName')), '2019-06-01-preview', 'Full').identity.principalId]"
+    },
+    "defaultDatalakeAccessKey": {
+      "type": "string",
+      "value": "[reference(variables('defaultDataLakeStorageDeployName')).outputs.storageAccountKey.value]"
     }
   }
 }


### PR DESCRIPTION
Updated ARM Templates:

* `key-vault.json`: Adds more complete tagging support
* `synapse-workspace`: Adds the default datalake storage account key as a template out