### PR TITLE
Add function for Assert-AzureAdAppRole

### DIFF
--- a/module/functions/azure/aad/Assert-AzureAdAppRole.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdAppRole.ps1
@@ -1,0 +1,85 @@
+# <copyright file="Assert-AzureAdAppRole.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+<#
+.SYNOPSIS
+Ensures that an AzureAD application role with the specified configuration exists.
+
+.DESCRIPTION
+Ensures that an AzureAD application role with the specified configuration exists, creating or updating as necessary.
+
+.PARAMETER AppObjectId
+The object ID of the AzureAD application of which to add the role to.
+
+.PARAMETER AppRoleId
+Used to search for an existing AzureAD application role or create one with the specified name.
+
+.PARAMETER DisplayName
+The display name for the application role.
+
+.PARAMETER Description
+The description for the application role.
+
+.PARAMETER Value
+The value for the application role.
+
+.PARAMETER AllowedMemberTypes
+Allowed member types for the application (User / Application)
+
+.OUTPUTS
+Microsoft.Azure.Commands.ActiveDirectory.PSADApplication
+#>
+function Assert-AzureAdAppRole
+{
+    [CmdletBinding()]
+    param 
+    (
+        [string] $AppObjectId,
+        [string] $AppRoleId,
+        [string] $DisplayName,
+        [string] $Description,
+        [string] $Value,
+        [string[]] $AllowedMemberTypes
+    )
+    
+    $GraphApiAppUri = ("https://graph.microsoft.com/v1.0/applications/{0}" -f $AppObjectId)
+
+    $App = Invoke-AzCliRestCommand -Uri $GraphApiAppUri
+
+    $AppRoles = $App.appRoles
+
+    $AppRole = $AppRoles | Where-Object { $_.id -eq $AppRoleId }
+
+    if ($AppRole) {
+        Write-Host "Updating $Value app role"
+
+        $AppRole.isEnabled = $true
+        $AppRole.description = $Description
+        $AppRole.value = $Value
+        $AppRole.allowedMemberTypes = $AllowedMemberTypes
+    }
+    else {
+        Write-Host "Adding $Value app role"
+
+        $AppRole = @{
+            displayName = $DisplayName
+            id = $AppRoleId
+            isEnabled = $true
+            description = $Description
+            value = $Value
+            allowedMemberTypes = $AllowedMemberTypes
+        }
+        $AppRoles += $AppRole
+    }
+
+    $UpdateResponse = Invoke-AzCliRestCommand `
+        -Uri $GraphApiAppUri `
+        -Method "PATCH" `
+        -Body @{appRoles=$AppRoles}
+
+    $App = Invoke-AzCliRestCommand -Uri $GraphApiAppUri
+
+    return $App
+    
+}

--- a/module/functions/azure/aad/Assert-AzureAdAppRole.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdAppRole.ps1
@@ -27,6 +27,9 @@ The value for the application role.
 .PARAMETER AllowedMemberTypes
 Allowed member types for the application (User / Application)
 
+.PARAMETER UseAzureAdGraph
+By default, the Microsoft Graph will be used for the graph operations. If you enable this switch, the legacy Azure AD Graph will be used instead.
+
 .OUTPUTS
 Microsoft.Azure.Commands.ActiveDirectory.PSADApplication
 #>
@@ -40,10 +43,18 @@ function Assert-AzureAdAppRole
         [string] $DisplayName,
         [string] $Description,
         [string] $Value,
-        [string[]] $AllowedMemberTypes
+        [string[]] $AllowedMemberTypes,
+        [switch] $UseAzureAdGraph
     )
     
-    $GraphApiAppUri = ("https://graph.microsoft.com/v1.0/applications/{0}" -f $AppObjectId)
+    $TenantId = (Get-AzContext).Tenant.Id
+
+    $AppUriSegment = ("applications/{0}" -f $AppObjectId)
+
+    $GraphApiAppUri = $UseAzureAdGraph ?
+        "https://graph.windows.net/{0}/{1}?api-version=1.5" -f $TenantId, $AppUriSegment : 
+        "https://graph.microsoft.com/v1.0/{0}" -f $AppUriSegment
+
 
     $App = Invoke-AzCliRestCommand -Uri $GraphApiAppUri
 


### PR DESCRIPTION
Function either adds new application role or updates existing one (if one exists with given ID).

This function is required by most (all?) Marain services' deployments.