### PR TITLE
Bump version of 'docker/build-push-action'

### DIFF
--- a/.github/workflows/publish_to_dockerhub.yml
+++ b/.github/workflows/publish_to_dockerhub.yml
@@ -46,7 +46,7 @@ jobs:
         config_file: .github/config/docker.json
 
     - name: Push to Docker Hub
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v2
       with:
         username: ${{ secrets.ENDJIN_DOCKERHUB_USERNAME  }}
         password: ${{ secrets.ENDJIN_DOCKERHUB_ACCESSTOKEN  }}


### PR DESCRIPTION
This should resolve the current deprecation error in this workflow.
