### PR TITLE
Adds 'Select-ExceptIn' function

### DIFF
--- a/module/functions/Select-ExceptIn.Tests.ps1
+++ b/module/functions/Select-ExceptIn.Tests.ps1
@@ -1,0 +1,159 @@
+# <copyright file="Select-ExceptIn.Tests.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+$here = Split-Path -Parent $PSCommandPath
+$sut = (Split-Path -Leaf $PSCommandPath) -replace ".Tests"
+
+. "$here\$sut"
+
+Describe "Sekect-ExceptIn Tests" {
+
+    $singleReference = @(
+        @{ Name = "foo"; Location = "uk"; Id = "1000" }
+    )
+    $multiReference = @(
+        @{ Name = "foo"; Location = "uk"; Id = "1000" }
+        @{ Name = "bar"; Location = "uk"; Id = "1001" }
+    )
+
+    Context "ValueFromPipeline" {
+        Context "Empty input array" {
+            $res = @() | Select-ExceptIn @()
+
+            It "should return no missing items" {
+                $res | Should -Be @()
+            }
+        }
+
+        Context "Empty reference array (single input)" {
+            $res = $singleReference | Select-ExceptIn @()
+
+            It "should return a single item array" {
+                $res.Count | Should -Be 1
+                $res[0] | Should -BeOfType System.Collections.Hashtable
+                $res[0].Keys.Count | Should -Be 3
+            }
+        }
+
+        Context "Empty reference array (multi input)" {
+            $res = $multiReference | Select-ExceptIn @()
+
+            It "should return all items" {
+                $res.Count | Should -Be 2
+                $res[0] | Should -BeOfType System.Collections.Hashtable
+                $res[1] | Should -BeOfType System.Collections.Hashtable
+                $res[0].Keys.Count | Should -Be 3
+                $res[1].Keys.Count | Should -Be 3
+            }
+        }
+
+        Context "No missing entry" {
+            $res = $singleReference | Select-ExceptIn $multiReference
+
+            It "should return no items" {
+                $res.Count | Should -Be 0
+            }
+        }
+
+        Context "No missing entries" {
+            $res = $multiReference | Select-ExceptIn $multiReference
+
+            It "should return no items" {
+                $res.Count | Should -Be 0
+            }
+        }
+
+        Context "Missing entry" {
+            $res = $multiReference | Select-ExceptIn $singleReference
+
+            It "should return the single missing item" {
+                $res.Count | Should -Be 1
+                $res[0] | Should -BeOfType System.Collections.Hashtable
+                $res[0].Keys.Count | Should -Be 3
+            }
+        }
+
+        Context "Missing entries" {
+            $res = $multiReference | Select-ExceptIn @{ Name = "test"; Location = "uk"; Id = "1002" }
+
+            It "should return all the missing items" {
+                $res.Count | Should -Be 2
+                $res[0] | Should -BeOfType System.Collections.Hashtable
+                $res[1] | Should -BeOfType System.Collections.Hashtable
+                $res[0].Keys.Count | Should -Be 3
+                $res[1].Keys.Count | Should -Be 3
+            }
+        }
+    }
+
+    Context "ValueFromParameter" {
+        Context "Empty input array" {
+            $res = Select-ExceptIn -InputObject @() -ReferenceArray @()
+
+            It "should return no missing items" {
+                $res | Should -Be @()
+            }
+        }
+
+        Context "Empty reference array (single input)" {
+            $res = Select-ExceptIn -InputObject $singleReference -ReferenceArray @()
+
+            It "should return a single item array" {
+                $res.Count | Should -Be 1
+                $res[0] | Should -BeOfType System.Collections.Hashtable
+                $res[0].Keys.Count | Should -Be 3
+            }
+        }
+
+        Context "Empty reference array (multi input)" {
+            $res = Select-ExceptIn -InputObject $multiReference -ReferenceArray @()
+
+            It "should return all items" {
+                $res.Count | Should -Be 2
+                $res[0] | Should -BeOfType System.Collections.Hashtable
+                $res[1] | Should -BeOfType System.Collections.Hashtable
+                $res[0].Keys.Count | Should -Be 3
+                $res[1].Keys.Count | Should -Be 3
+            }
+        }
+
+        Context "No missing entry" {
+            $res = Select-ExceptIn -InputObject $singleReference -ReferenceArray $multiReference
+
+            It "should return no items" {
+                $res.Count | Should -Be 0
+            }
+        }
+
+        Context "No missing entries" {
+            $res = Select-ExceptIn -InputObject $multiReference -ReferenceArray $multiReference
+
+            It "should return no items" {
+                $res.Count | Should -Be 0
+            }
+        }
+
+        Context "Missing entry" {
+            $res = Select-ExceptIn -InputObject $multiReference -ReferenceArray $singleReference
+
+            It "should return the single missing item" {
+                $res.Count | Should -Be 1
+                $res[0] | Should -BeOfType System.Collections.Hashtable
+                $res[0].Keys.Count | Should -Be 3
+            }
+        }
+
+        Context "Missing entries" {
+            $res = Select-ExceptIn -InputObject $multiReference -ReferenceArray @{ Name = "test"; Location = "uk"; Id = "1002" }
+
+            It "should return all the missing items" {
+                $res.Count | Should -Be 2
+                $res[0] | Should -BeOfType System.Collections.Hashtable
+                $res[1] | Should -BeOfType System.Collections.Hashtable
+                $res[0].Keys.Count | Should -Be 3
+                $res[1].Keys.Count | Should -Be 3
+            }
+        }
+    }
+}

--- a/module/functions/Select-ExceptIn.Tests.ps1
+++ b/module/functions/Select-ExceptIn.Tests.ps1
@@ -85,6 +85,40 @@ Describe "Sekect-ExceptIn Tests" {
                 $res[1].Keys.Count | Should -Be 3
             }
         }
+
+        Context "Mismatched key ordering" {
+            # Ensures that hashtables with keys in a different order should not affect the output
+            $input = @(
+                @{ Name = "foo"; Location = "uk"; Id = "1000" }   
+            )
+
+            $reference = @(
+                @{ Name = "foo"; Id = "1000"; Location = "uk" }
+            )
+
+            $res = $input | Select-ExceptIn $reference
+
+            It "should still correctly identify the matching entries" {
+                $res.Count | Should -Be 0
+            }
+        }
+
+        Context "Mismatched key names" {
+            # Ensures that hashtables with the same values but different keys is properly compared
+            $input = @(
+                @{ Name = "foo"; Location = "uk"; Id = "1000" }   
+            )
+
+            $reference = @(
+                @{ Name = "foo"; Locale = "uk"; Identifier = "1000" }
+            )
+
+            $res = $input | Select-ExceptIn $reference
+
+            It "should correctly identify the missing entry" {
+                $res.Count | Should -Be 1
+            }
+        }
     }
 
     Context "ValueFromParameter" {
@@ -153,6 +187,40 @@ Describe "Sekect-ExceptIn Tests" {
                 $res[1] | Should -BeOfType System.Collections.Hashtable
                 $res[0].Keys.Count | Should -Be 3
                 $res[1].Keys.Count | Should -Be 3
+            }
+        }
+
+        Context "Mismatched key ordering" {
+            # Ensures that hashtables with keys in a different order should not affect the output
+            $input = @(
+                @{ Name = "foo"; Location = "uk"; Id = "1000" }   
+            )
+
+            $reference = @(
+                @{ Name = "foo"; Id = "1000"; Location = "uk" }
+            )
+
+            $res = Select-ExceptIn -InputObject $input -ReferenceArray $reference
+
+            It "should still correctly identify the matching entries" {
+                $res.Count | Should -Be 0
+            }
+        }
+
+        Context "Mismatched key names" {
+            # Ensures that hashtables with the same values but different keys is properly compared
+            $input = @(
+                @{ Name = "foo"; Location = "uk"; Id = "1000" }   
+            )
+
+            $reference = @(
+                @{ Name = "foo"; Locale = "uk"; Identifier = "1000" }
+            )
+
+            $res = Select-ExceptIn -InputObject $input -ReferenceArray $reference
+
+            It "should correctly identify the missing entry" {
+                $res.Count | Should -Be 1
             }
         }
     }

--- a/module/functions/Select-ExceptIn.Tests.ps1
+++ b/module/functions/Select-ExceptIn.Tests.ps1
@@ -7,7 +7,7 @@ $sut = (Split-Path -Leaf $PSCommandPath) -replace ".Tests"
 
 . "$here\$sut"
 
-Describe "Sekect-ExceptIn Tests" {
+Describe "Select-ExceptIn Tests" {
 
     $singleReference = @(
         @{ Name = "foo"; Location = "uk"; Id = "1000" }

--- a/module/functions/Select-ExceptIn.ps1
+++ b/module/functions/Select-ExceptIn.ps1
@@ -17,7 +17,7 @@ The array of hashtables that should exist in the reference array.
 The array of hashtables to be compared with the input array.
 
 .OUTPUTS
-An array of hashtables representing the input hashtables that do not existing in the reference array.
+An array of hashtables representing the input hashtables that do not exist in the reference array.
 
 .EXAMPLE
 $input = @(

--- a/module/functions/Select-ExceptIn.ps1
+++ b/module/functions/Select-ExceptIn.ps1
@@ -57,12 +57,17 @@ function Select-ExceptIn
 
     Process {
         foreach ($inputItem in $InputObject) {
+            $inputItemToCompare = _sortedHashtable($inputItem)
+
             # Assume the item is missing unless we find a match
             $isMissing = $true
             foreach ($referenceItem in $ReferenceArray) {
-                $res = Compare-Object $referenceItem.Values $inputItem.Values
-                if (!$res) {
-                    # When the comparison returns null then we have found a hashtable in the
+                $refItemToCompare = _sortedHashtable($referenceItem)
+
+                $keysDiff = Compare-Object $refItemToCompare.Keys $inputItemToCompare.Keys
+                $valuesDiff = Compare-Object $refItemToCompare.Values $inputItemToCompare.Values
+                if (!$keysDiff -and !$valuesDiff) {
+                    # When the comparisons return null then we have found a hashtable in the
                     # reference array that exactly matches the input item currently being
                     # processed.
                     
@@ -81,4 +86,20 @@ function Select-ExceptIn
     End {
         @(,$results)
     }
+}
+
+function _sortedHashtable
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [hashtable] $Hashtable
+    )
+
+    $sortedHashtable = [ordered]@{}
+    $Hashtable.Keys | Sort-Object | ForEach-Object {
+        $sortedHashtable.Add($_, $Hashtable[$_])
+    }
+
+    $sortedHashtable
 }

--- a/module/functions/Select-ExceptIn.ps1
+++ b/module/functions/Select-ExceptIn.ps1
@@ -10,6 +10,22 @@ Compares two Hashtable arrays and returns the hashtable entries from the input t
 This is intended to find hashtable-based objects that are missing from the reference array of hashtables.  For
 example, as part of some synchronisation logic.
 
+NOTE: This function does not support nested hashtables as it relies on Compare-Object for the comparison of
+each hashtable key.
+
+.NOTES
+This function's primary use-case is to support determining how a 'desired state' differs from a 'current state'.
+
+For example, comparing the current Azure resource manager permissions with those defined in configuration.
+
+In this case the the raw objects cannot be compared as they have different properties - the current state will be
+available as the 'Microsoft.Azure.Commands.Resources.Models.Authorization.PSRoleAssignment' type, whilst the configuration
+may defined with a much simpler hashtable structure.
+
+Therefore the usage of this function assumes that custom projections will be created that map the current and
+desired states into a common structure and it is those projections that get passed to this function.  It is then
+the responsibility of the consumer to interpret the results for their particular scenario.
+
 .PARAMETER InputObject
 The array of hashtables that should exist in the reference array.
 

--- a/module/functions/Select-ExceptIn.ps1
+++ b/module/functions/Select-ExceptIn.ps1
@@ -1,0 +1,84 @@
+# <copyright file="Select-ExceptIn.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+<#
+.SYNOPSIS
+Compares two Hashtable arrays and returns the hashtable entries from the input that don't exist in the reference array.
+
+.DESCRIPTION
+This is intended to find hashtable-based objects that are missing from the reference array of hashtables.  For
+example, as part of some synchronisation logic.
+
+.PARAMETER InputObject
+The array of hashtables that should exist in the reference array.
+
+.PARAMETER ReferenceArray
+The array of hashtables to be compared with the input array.
+
+.OUTPUTS
+An array of hashtables representing the input hashtables that do not existing in the reference array.
+
+.EXAMPLE
+$input = @(
+    @{ Name="foo"; Id=1 }
+    @{ Name="foobar"; Id=3 }
+)
+$reference = @(
+    @{ Name="bar"; Id=100 }
+    @{ Name="foobar"; Id=3 }
+)
+
+$input | Select-ExceptIn $reference
+
+The output would be:
+@(
+    @{ Name="foo"; Id=1 }
+)
+
+#>
+
+function Select-ExceptIn
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [AllowEmptyCollection()]
+        [Hashtable[]] $InputObject,
+
+        [Parameter(Mandatory = $true, Position = 0)]
+        [AllowEmptyCollection()]
+        [Hashtable[]] $ReferenceArray
+	)
+
+    Begin {
+        $results = @()
+    }
+
+    Process {
+        foreach ($inputItem in $InputObject) {
+            # Assume the item is missing unless we find a match
+            $isMissing = $true
+            foreach ($referenceItem in $ReferenceArray) {
+                $res = Compare-Object $referenceItem.Values $inputItem.Values
+                if (!$res) {
+                    # When the comparison returns null then we have found a hashtable in the
+                    # reference array that exactly matches the input item currently being
+                    # processed.
+                    
+                    # Record that it is not missing and abandon this inner loop
+                    $isMissing = $false
+                    break
+                }
+            }
+
+            if ($isMissing) {
+                $results += $inputItem
+            }
+        }
+    }
+
+    End {
+        @(,$results)
+    }
+}


### PR DESCRIPTION
New Cmdlets:
- `Select-ExceptIn` - Aims to emulate the 'Except' LINQ keyword to facilitate comparing collections of hashtable-based objects