### PR TITLE
Updated 'Invoke-CommandWithRetry' to log more useful error messages

### DIFF
--- a/module/functions/Invoke-CommandWithRetry.Tests.ps1
+++ b/module/functions/Invoke-CommandWithRetry.Tests.ps1
@@ -9,11 +9,18 @@ function _logRetry {}
 Describe "Invoke-CommandWithRetry" {
     
     Context "When the command does not error" {
+        Mock _logRetry {}
+        Mock Write-Host {}
 
         $result = Invoke-CommandWithRetry { return $true }
 
         It "should return the output" {
             $result | Should Be $true
+        }
+
+        It "should not log a success after retry" {
+            Assert-MockCalled _logRetry -Times 0
+            Assert-MockCalled Write-Host -Times 0
         }
     }
 
@@ -48,6 +55,7 @@ Describe "Invoke-CommandWithRetry" {
     Context "When the command eventually passes" {
         Mock _logRetry {}
         Mock Write-Warning {}
+        Mock Write-Host {}
 
         $global:failureCount = 0;
 
@@ -74,6 +82,10 @@ Describe "Invoke-CommandWithRetry" {
 
         It "should return the output" {
             $result | Should Be $true
+        }
+
+        It "should log a success after retry" {
+            Assert-MockCalled Write-Host -Times 1
         }
     }
 

--- a/module/functions/Invoke-CommandWithRetry.Tests.ps1
+++ b/module/functions/Invoke-CommandWithRetry.Tests.ps1
@@ -4,7 +4,7 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".p
 . "$here\$sut"
 
 # Ensure this internal function is available for mocking
-function _logWarning {}
+function _logRetry {}
 
 Describe "Invoke-CommandWithRetry" {
     
@@ -18,31 +18,36 @@ Describe "Invoke-CommandWithRetry" {
     }
 
     Context "When the command does error" {
-        Mock _logWarning {}
+        Mock _logRetry {}
+        Mock Write-Warning {}
 
         It "should bubble up the exception" {
-            { Invoke-CommandWithRetry { throw "force retry" } -RetryDelay 0 } | Should Throw
+            { Invoke-CommandWithRetry { throw "force retry" } -RetryDelay 0 } | Should Throw "force retry"
+            Assert-MockCalled Write-Warning -Times 1
         }
 
         It "should retry 5 times by default" {
-            Assert-MockCalled _logWarning -Times 5
+            Assert-MockCalled _logRetry -Times 5
         }
     }
 
-    Context "When the retry count is changed overriden" {
-        Mock _logWarning {}
+    Context "When the retry count is overridden" {
+        Mock _logRetry {}
+        Mock Write-Warning {}
 
         It "should bubble up the exception" {
-            { Invoke-CommandWithRetry { throw "force retry" } -RetryDelay 0 -RetryCount 10 } | Should Throw
+            { Invoke-CommandWithRetry { throw "force retry" } -RetryDelay 0 -RetryCount 10 } | Should Throw "force retry"
+            Assert-MockCalled Write-Warning -Times 1
         }
 
         It "should retry the specified amount of times" {
-            Assert-MockCalled _logWarning -Times 10
+            Assert-MockCalled _logRetry -Times 10
         }
     }
 
     Context "When the command eventually passes" {
-        Mock _logWarning {}
+        Mock _logRetry {}
+        Mock Write-Warning {}
 
         $global:failureCount = 0;
 
@@ -60,10 +65,11 @@ Describe "Invoke-CommandWithRetry" {
 
         It "should not bubble the exception" {
             $result | Should Not Throw
+            Assert-MockCalled Write-Warning -Times 0
         }
 
         It "should log attempting the retries" {
-            Assert-MockCalled _logWarning -Times 2
+            Assert-MockCalled _logRetry -Times 2
         }
 
         It "should return the output" {

--- a/module/functions/Invoke-CommandWithRetry.ps1
+++ b/module/functions/Invoke-CommandWithRetry.ps1
@@ -36,9 +36,9 @@ function Invoke-CommandWithRetry
     $success = $false
 
     # Private functions for mocking purposes
-    function _logWarning($delay)
+    function _logRetry($delay,$errorRecord)
     {
-        Write-Warning ("Command failed - retrying in {0} seconds" -f $delay)
+        Write-Warning ("Command failed - $($errorRecord.Exception.Message) - retrying in {0} seconds" -f $delay)
     }
 
     do
@@ -53,10 +53,11 @@ function Invoke-CommandWithRetry
         catch
         {   
             if ($currentRetry -ge $RetryCount) {
-                throw ("Exceeded retry limit when running command [{0}]" -f $Command)
+                Write-Warning ("Exceeded retry limit when running command [{0}]" -f $Command)
+                throw $_
             }
             else {
-                _logWarning $RetryDelay
+                _logRetry $RetryDelay $_
                 Start-Sleep -s $RetryDelay
             }
             $currentRetry++

--- a/module/functions/Invoke-CommandWithRetry.ps1
+++ b/module/functions/Invoke-CommandWithRetry.ps1
@@ -49,6 +49,11 @@ function Invoke-CommandWithRetry
             $result = Invoke-Command $command -ErrorAction Stop
             Write-Verbose ("Command succeeded." -f $Command)
             $success = $true
+
+            # It is helpful to explicitly log when it succeeds after having to retry
+            if ($currentRetry -gt 0) {
+                Write-Host "Command succeeded on retry attempt: $currentRetry"
+            }
         }
         catch
         {   


### PR DESCRIPTION
Updated Cmdlets
* `Invoke-CommandWithRetry` - no longer masks the details of errors that cause a retry