### PR TITLE
Updated ARM templates for Synapse VNet integration and private link endpoints

### DIFF
--- a/module/arm-artifacts/shared-templates/storage-account.json
+++ b/module/arm-artifacts/shared-templates/storage-account.json
@@ -47,6 +47,14 @@
     "tagValues": {
       "type": "object",
       "defaultValue": {}
+    },
+    "enabledAdlsPrivateEndpoint": {
+      "type": "bool",
+      "defaultValue": false
+    },
+    "subnetResourceId": {
+      "type": "string",
+      "defaultValue": ""
     }
   },
   "variables": {
@@ -86,6 +94,82 @@
       "copy": {
           "name": "storageContainers",
           "count": "[if(not(empty(parameters('storageContainerNames'))), length(parameters('storageContainerNames')), 1)]"
+      }
+    },
+    {
+      "condition": "[parameters('enabledAdlsPrivateEndpoint')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[concat(deployment().name, '-private-endpoints')]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]"
+      ],
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "storageAccountName": {
+            "value": "[parameters('storageAccountName')]"
+          },
+          "subnetResourceId": {
+            "value": "[parameters('subnetResourceId')]"
+          },
+          "location": {
+            "value": "[parameters('storageAccountLocation')]"
+          },
+          "tags": {
+            "value": "[parameters('tagValues')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "storageAccountName": {
+              "type": "string"
+            },
+            "subnetResourceId": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string"
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {}
+            }
+          },
+          "variables": {
+            "privateEndpointBaseName": "[concat('private-endpoint-adls-', parameters('storageAccountName'))]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Network/privateEndpoints",
+              "apiVersion": "2020-06-01",
+              "name": "[toLower(variables('privateEndpointBaseName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "subnet": {
+                  "id": "[parameters('subnetResourceId')]"
+                },
+                "privateLinkServiceConnections": [
+                  {
+                    "name": "[toLower(variables('privateEndpointBaseName'))]",
+                    "properties": {
+                      "privateLinkServiceId": "[resourceId('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
+                      "groupIds": [
+                        "dfs"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "tags": "[parameters('tags')]"
+            }
+          ]
+        }
       }
     }
   ],

--- a/module/arm-artifacts/shared-templates/synapse-workspace.json
+++ b/module/arm-artifacts/shared-templates/synapse-workspace.json
@@ -146,6 +146,19 @@
       "type": "int",
       "defaultValue": 15
     },
+    "synapsePrivateEndpointSubnetResourceId": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "synapsePrivateEndpointServices": {
+      "type": "array",
+      "defaultValue": [],
+      "allowedValues": [
+        "Dev",
+        "Sql",
+        "SqlOnDemand"
+      ] 
+    },
     "workspaceRepositoryConfiguration": {
       "type": "object",
       "defaultValue": {}
@@ -264,6 +277,97 @@
         "[concat('Microsoft.Resources/deployments/', parameters('defaultDataLakeStorageFilesystemName'))]"
       ],
       "tags": "[variables('tags')]"
+    },
+    {
+      "condition": "[not(empty(parameters('synapsePrivateEndpointServices')))]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "[concat(deployment().name, '-private-endpoints')]",
+      "dependsOn": [
+        "[concat('Microsoft.Synapse/workspaces/', parameters('workspaceName'))]"
+      ],
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "synapsePrivateEndpointSubnetResourceId": {
+            "value": "[parameters('synapsePrivateEndpointSubnetResourceId')]"
+          },
+          "synapsePrivateEndpointServices": {
+            "value": "[parameters('synapsePrivateEndpointServices')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "workspaceName": {
+            "value": "[parameters('workspaceName')]"
+          },
+          "tags": {
+            "value": "[parameters('tagValues')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "synapsePrivateEndpointSubnetResourceId": {
+              "type": "string"
+            },
+            "synapsePrivateEndpointServices": {
+              "type": "array",
+              "allowedValues": [
+                "Dev",
+                "Sql",
+                "SqlOnDemand"
+              ]
+            },
+            "workspaceName": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string"
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {}
+            }
+          },
+          "variables": {
+            "privateEndpointBaseName": "[concat('private-endpoint-synapse-', parameters('workspaceName'))]",
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Network/privateEndpoints",
+              "apiVersion": "2020-06-01",
+              "name": "[toLower(concat(variables('privateEndpointBaseName'), '-', parameters('synapsePrivateEndpointServices')[copyIndex()]))]",
+              "copy": {
+                "name": "endpointCopy",
+                "count": "[length(parameters('synapsePrivateEndpointServices'))]"
+              },
+              "location": "[parameters('location')]",
+              "properties": {
+                "subnet": {
+                  "id": "[parameters('synapsePrivateEndpointSubnetResourceId')]"
+                },
+                "privateLinkServiceConnections": [
+                  {
+                    "name": "[toLower(concat(variables('privateEndpointBaseName'), '-', parameters('synapsePrivateEndpointServices')[copyIndex()]))]",
+                    "properties": {
+                      "privateLinkServiceId": "[resourceId('Microsoft.Synapse/workspaces/', parameters('workspaceName'))]",
+                      "groupIds": [
+                        "[parameters('synapsePrivateEndpointServices')[copyIndex()]]"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "tags": "[parameters('tags')]"
+            }
+          ]
+        }
+      }
     },
     {
       "condition": "[parameters('setWorkspaceIdentityRbacOnStorageAccount')]",

--- a/module/arm-artifacts/shared-templates/synapse-workspace.json
+++ b/module/arm-artifacts/shared-templates/synapse-workspace.json
@@ -156,9 +156,9 @@
     "storageBlobDataContributorRoleID": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
     "defaultDataLakeStorageAccountUrl": "[concat('https://', parameters('defaultDataLakeStorageAccountName'), '.dfs.core.windows.net')]",
     "defaultDataLakeStorageDeployName": "[concat(deployment().name, '-defsa')]",
-    "synapseManagedIdentityRoleAssignmentId": "[guid(concat(resourceGroup().id, '/', variables('storageBlobDataContributorRoleID'), '/', parameters('workspaceName'), '/', 'synapse-managed-identity'))]",
-    "datalakeContributorRoleAssignmentId": "[guid(concat(resourceGroup().id, '/', variables('storageBlobDataContributorRoleID'), '/', parameters('datalakeContributorGroupId'), '/', 'datalake-contributor-group'))]",
-    "defaultDataLakeStorageResourceReaderRoleAssignmentId": "[guid(concat(resourceGroup().id, '/', variables('readerRoleID'), '/', parameters('datalakeContributorGroupId'), '/', 'datalake-contributor-group'))]",
+    "synapseManagedIdentityRoleAssignmentIdBaseEntropy": "[concat(resourceGroup().id, '/', parameters('defaultDataLakeStorageAccountName'), '/', variables('storageBlobDataContributorRoleID'), '/', parameters('workspaceName'))]",
+    "defaultDatalakeDataContributorRoleAssignmentId": "[guid(concat(resourceGroup().id, '/', parameters('defaultDataLakeStorageAccountName'), '/', variables('storageBlobDataContributorRoleID'), '/', parameters('datalakeContributorGroupId'), '/', 'datalake-contributor-group'))]",
+    "defaultDatalakeResourceReaderRoleAssignmentId": "[guid(concat(resourceGroup().id, '/', parameters('defaultDataLakeStorageAccountName'), '/', variables('readerRoleID'), '/', parameters('datalakeContributorGroupId'), '/', 'datalake-contributor-group'))]",
     "defaultSparkPoolNameSafe": "[if(equals(parameters('defaultSparkPoolName'),''), 'not-required', parameters('defaultSparkPoolName'))]",
     "localTags": {
       "displayName": "[parameters('workspaceName')]"
@@ -286,7 +286,7 @@
             {
               "type": "Microsoft.Storage/storageAccounts/providers/roleAssignments",
               "apiVersion": "2018-09-01-preview",
-              "name": "[concat(parameters('defaultDataLakeStorageAccountName'), '/Microsoft.Authorization/', variables('synapseManagedIdentityRoleAssignmentId'))]",
+              "name": "[concat(parameters('defaultDataLakeStorageAccountName'), '/Microsoft.Authorization/', guid(concat(variables('synapseManagedIdentityRoleAssignmentIdBaseEntropy'), '/', reference(concat('Microsoft.Synapse/workspaces/', parameters('workspaceName')), '2019-06-01-preview', 'Full').identity.principalId)))]",
               "location": "[parameters('storageLocation')]",
               "properties": {
                 "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('storageBlobDataContributorRoleID'))]",
@@ -298,7 +298,7 @@
               "condition": "[parameters('setSbdcRbacOnStorageAccount')]",
               "type": "Microsoft.Storage/storageAccounts/providers/roleAssignments",
               "apiVersion": "2018-09-01-preview",
-              "name": "[concat(parameters('defaultDataLakeStorageAccountName'), '/Microsoft.Authorization/', variables('datalakeContributorRoleAssignmentId'))]",
+              "name": "[concat(parameters('defaultDataLakeStorageAccountName'), '/Microsoft.Authorization/', variables('defaultDatalakeDataContributorRoleAssignmentId'))]",
               "properties": {
                 "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('storageBlobDataContributorRoleID'))]",
                 "principalId": "[parameters('datalakeContributorGroupId')]",
@@ -309,7 +309,7 @@
               "condition": "[parameters('setSbdcRbacOnStorageAccount')]",
               "type": "Microsoft.Storage/storageAccounts/providers/roleAssignments",
               "apiVersion": "2018-09-01-preview",
-              "name": "[concat(parameters('defaultDataLakeStorageAccountName'), '/Microsoft.Authorization/', variables('defaultDataLakeStorageResourceReaderRoleAssignmentId'))]",
+              "name": "[concat(parameters('defaultDataLakeStorageAccountName'), '/Microsoft.Authorization/', variables('defaultDatalakeResourceReaderRoleAssignmentId'))]",
               "properties": {
                 "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('readerRoleId'))]",
                 "principalId": "[parameters('datalakeContributorGroupId')]",


### PR DESCRIPTION
Updated ARM Templates:
* `storage-account.json` :  Adds support for deploying a PrivateLink endpoint for the storage account
* `synapse-worksapce.son` : Adds support for configuring Synapse VNet integration and PrivateLink endpoints and resolves a bug with potential colliding RBAC assignment IDs