### PR TITLE
Adds support for deploying Bicep templates

### DIFF
--- a/module/functions/azure/Invoke-ArmTemplateDeployment.ps1
+++ b/module/functions/azure/Invoke-ArmTemplateDeployment.ps1
@@ -67,7 +67,7 @@ function Invoke-ArmTemplateDeployment
         [Parameter(Mandatory=$true)]
         [string] $ArmTemplatePath,
 
-        [ValidateSet("ResourceGroup","Subscription","Tenant")]
+        [ValidateSet("ResourceGroup","Subscription","ManagementGroup","Tenant")]
         [string] $DeploymentScope = "ResourceGroup",
 
         [string] $ResourceGroupName,

--- a/module/functions/azure/Invoke-ArmTemplateDeployment.ps1
+++ b/module/functions/azure/Invoke-ArmTemplateDeployment.ps1
@@ -85,18 +85,18 @@ function Invoke-ArmTemplateDeployment
     $OptionalParameters = @{}
 
     # Check whether we have a valid AzPowerShell connection
-    _EnsureAzureConnection -AzPowerShell -ErrorAction Stop
+    _EnsureAzureConnection -AzPowerShell -ErrorAction Stop | Out-Null
 
     # ensure Bicep cli is installed and available to Az.PowerShell, if needed
     if ($ArmTemplatePath.ToLower().EndsWith(".bicep")) {
         if (!(Get-Command bicep -ErrorAction SilentlyContinue)) {
             Write-Host "Bootstrapping Bicep cli tool..."
-            & az bicep install --version v0.3.539
-            & az bicep version
+            & az bicep install --version v0.3.539 | Out-String | Write-Verbose
+            & az bicep version | Out-String | Write-Verbose
             $bicepPath = [IO.Path]::Join($env:HOME, ".azure", "bin")
             $env:PATH = "$($env:PATH){0}$bicepPath" -f [IO.Path]::PathSeparator
             # verify the install
-            Get-Command bicep | Select-Object -ExpandProperty Path
+            Get-Command bicep | Select-Object -ExpandProperty Path | Out-String | Write-Verbose
         }
     }
 
@@ -113,7 +113,7 @@ function Invoke-ArmTemplateDeployment
     # Create the resource group only when it doesn't already exist
     if ( $DeploymentType -eq "ResourceGroup" -and `
             $null -eq (Get-AzResourceGroup -Name $ResourceGroupName -Verbose -ErrorAction SilentlyContinue) ) {
-        New-AzResourceGroup -Name $ResourceGroupName -Location $Location -Verbose -Force -ErrorAction Stop
+        New-AzResourceGroup -Name $ResourceGroupName -Location $Location -Verbose -Force -ErrorAction Stop | Out-Null
     }
 
     # Setup required parameters for the relevant deployment type

--- a/module/functions/azure/Invoke-ArmTemplateDeployment.ps1
+++ b/module/functions/azure/Invoke-ArmTemplateDeployment.ps1
@@ -12,8 +12,8 @@ creating the target resource group (if necessary) and invoking the deployment of
 
 Also provides support for retries for any errors not caused by 'InvalidTemplate' exceptions.
 
-.PARAMETER DeploymentType
-The type of ARM deployment (e.g. Resource Group, Subscription, Tenant)
+.PARAMETER DeploymentScope
+The target scope of the ARM deployment (e.g. Resource Group, Subscription, Tenant)
 
 .PARAMETER ResourceGroupName
 The name of the target resource group.
@@ -68,7 +68,7 @@ function Invoke-ArmTemplateDeployment
         [string] $ArmTemplatePath,
 
         [ValidateSet("ResourceGroup","Subscription","Tenant")]
-        [string] $DeploymentType = "ResourceGroup",
+        [string] $DeploymentScope = "ResourceGroup",
 
         [string] $ResourceGroupName,
 

--- a/module/functions/azure/Invoke-ArmTemplateDeployment.ps1
+++ b/module/functions/azure/Invoke-ArmTemplateDeployment.ps1
@@ -111,14 +111,14 @@ function Invoke-ArmTemplateDeployment
     }
 
     # Create the resource group only when it doesn't already exist
-    if ( $DeploymentType -eq "ResourceGroup" -and `
+    if ( $DeploymentScope -eq "ResourceGroup" -and `
             $null -eq (Get-AzResourceGroup -Name $ResourceGroupName -Verbose -ErrorAction SilentlyContinue) ) {
         New-AzResourceGroup -Name $ResourceGroupName -Location $Location -Verbose -Force -ErrorAction Stop | Out-Null
     }
 
     # Setup required parameters for the relevant deployment type
     $argsForDeployType = @{ TemplateFile = $ArmTemplatePath }
-    if ($DeploymentType -eq "ResourceGroup") {
+    if ($DeploymentScope -eq "ResourceGroup") {
         $argsForDeployType += @{ ResourceGroupName = $ResourceGroupName }
     }
     else {
@@ -127,7 +127,7 @@ function Invoke-ArmTemplateDeployment
 
     Write-Host "Validating ARM template ($ArmTemplatePath)..."
     # Dynamically call the relevant cmdlet for the current deployment type
-    $validationErrors = & "Test-Az$($DeploymentType)Deployment" `
+    $validationErrors = & "Test-Az$($DeploymentScope)Deployment" `
                                     @argsForDeployType `
                                     @OptionalParameters `
                                     @TemplateParameters `
@@ -143,8 +143,8 @@ function Invoke-ArmTemplateDeployment
     $DeploymentResult = $null
     $success = $false
 
-    # DeploymentType specific args for the actual deployment
-    if ($DeploymentType -eq "ResourceGroup") {
+    # DeploymentScope specific args for the actual deployment
+    if ($DeploymentScope -eq "ResourceGroup") {
         $argsForDeployType += @{ Force = $True }
     }
 
@@ -158,7 +158,7 @@ function Invoke-ArmTemplateDeployment
         try {
             Write-Host "Deploying ARM template ($ArmTemplatePath)..."
             # Dynamically call the relevant cmdlet for the current deployment type
-            $DeploymentResult = & "New-Az$($DeploymentType)Deployment" `
+            $DeploymentResult = & "New-Az$($DeploymentScope)Deployment" `
                                         -Name $deployName `
                                         @argsForDeployType `
                                         @OptionalParameters `

--- a/module/functions/azure/_DeployArmArtifacts.ps1
+++ b/module/functions/azure/_DeployArmArtifacts.ps1
@@ -4,10 +4,10 @@
 
 <#
 .SYNOPSIS
-Handles uploading linked ARM templates and other artifacts to a staging sstorage account.
+Handles uploading linked ARM templates and other artifacts to a staging storage account.
 
 .DESCRIPTION
-Handles uploading linked ARM templates and other artifacts to a staging sstorage account.
+Handles uploading linked ARM templates and other artifacts to a staging storage account.
 
 .PARAMETER AdditionalArtifactsFolderPath
 The file system path to additional linked ARM templates that need to be staged. The path should be to a directory that contains a

--- a/module/functions/azure/_DeployArmArtifacts.ps1
+++ b/module/functions/azure/_DeployArmArtifacts.ps1
@@ -1,3 +1,38 @@
+# <copyright file="_DeployArmArtifacts.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+<#
+.SYNOPSIS
+Handles uploading linked ARM templates and other artifacts to a staging sstorage account.
+
+.DESCRIPTION
+Handles uploading linked ARM templates and other artifacts to a staging sstorage account.
+
+.PARAMETER AdditionalArtifactsFolderPath
+The file system path to additional linked ARM templates that need to be staged. The path should be to a directory that contains a
+directory named 'templates', within which these templates should reside.
+
+.PARAMETER SharedArtifactsFolderPath
+The file system path to the set of shared linked ARM templates that need to be staged. If using the library of such templates contained
+within this module, then this need not be specified.
+
+.PARAMETER StagingStorageAccountName
+The Azure storage account to use for staging ARM artifacts. When not specified, a name will be generated based on the Azure location and
+subscription ID. (e.g. 'stageeastus1234567890123)
+
+.PARAMETER StorageResourceGroupName
+The resource group where the Azure storage account used for staging ARM artifacts resides. When not specified, a name will be derived based on
+the Azure location.
+
+.PARAMETER ArtifactsLocationName
+The name of the parameter used by the main ARM template to refer to the location of the staged ARM artifacts.
+
+.PARAMETER ArtifactsLocationSasTokenName
+The name of the parameter used by the main ARM template to refer to the SAS token that has access to the Azure storage account used for staging
+ARM artifacts.
+
+#>
 function _DeployArmArtifacts
 {
     [CmdletBinding()]
@@ -18,6 +53,9 @@ function _DeployArmArtifacts
         [string] $StagingStorageAccountName
 
     )
+
+    # Check whether we have a valid AzPowerShell connection
+    _EnsureAzureConnection -AzPowerShell -ErrorAction Stop | Out-Null
 
     if (!$StagingStorageAccountName) {
         $StagingStorageAccountName = ('stage{0}{1}' -f $Location, ($script:moduleContext.SubscriptionId.ToString()).Replace('-', '').ToLowerInvariant()).SubString(0, 24)

--- a/module/functions/azure/_DeployArmArtifacts.ps1
+++ b/module/functions/azure/_DeployArmArtifacts.ps1
@@ -1,0 +1,76 @@
+function _DeployArmArtifacts
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [string] $SharedArtifactsFolderPath,
+
+        [Parameter(Mandatory=$true)]
+        [string] $StorageResourceGroupName,
+
+        [Parameter(Mandatory=$true)]
+        [string] $ArtifactsLocationName,
+
+        [Parameter(Mandatory=$true)]
+        [string] $ArtifactsLocationSasTokenName,
+
+        [string] $AdditionalArtifactsFolderPath,
+        [string] $StagingStorageAccountName
+
+    )
+
+    if (!$StagingStorageAccountName) {
+        $StagingStorageAccountName = ('stage{0}{1}' -f $Location, ($script:moduleContext.SubscriptionId.ToString()).Replace('-', '').ToLowerInvariant()).SubString(0, 24)
+    }
+    $StorageContainerName = $ResourceGroupName.ToLowerInvariant().Replace(".", "") + '-stageartifacts'
+
+    # Lookup whether the storage account already exists elsewhere in the current subscription
+    $StorageAccount = Get-AzStorageAccount | Where-Object { $_.StorageAccountName -eq $StagingStorageAccountName }
+
+    # Create the storage account if it doesn't already exist
+    if ($null -eq $StorageAccount) {
+        New-AzResourceGroup -Location $Location -Name $StorageResourceGroupName -Force
+        $StorageAccount = New-AzStorageAccount -StorageAccountName $StagingStorageAccountName `
+                                               -Type 'Standard_LRS' `
+                                               -ResourceGroupName $StorageResourceGroupName `
+                                               -Location $Location
+    }
+
+    # Copy files from the local storage staging location to the storage account container
+    New-AzStorageContainer -Name $StorageContainerName -Context $StorageAccount.Context -ErrorAction SilentlyContinue *>&1
+
+    # upload shared linked templates
+    $sharedArtifactFilePaths = Get-ChildItem $SharedArtifactsFolderPath -Recurse -File | ForEach-Object -Process {$_.FullName}
+    foreach ($SourcePath in $sharedArtifactFilePaths) {
+        Set-AzStorageBlobContent `
+            -File $SourcePath `
+            -Blob $SourcePath.Substring($SharedArtifactsFolderPath.length + 1) `
+            -Container $StorageContainerName `
+            -Context $StorageAccount.Context `
+            -Force `
+            -Verbose:$false | Out-Null
+    }
+
+    # upload any additional linked templates
+    if ($AdditionalArtifactsFolderPath) {
+        $additionalArtifactFilePaths = Get-ChildItem $AdditionalArtifactsFolderPath -Recurse -File | ForEach-Object -Process {$_.FullName}
+        foreach ($SourcePath in $additionalArtifactFilePaths) {
+            Set-AzStorageBlobContent `
+                -File $SourcePath `
+                -Blob $SourcePath.Substring($AdditionalArtifactsFolderPath.length + 1) `
+                -Container $StorageContainerName `
+                -Context $StorageAccount.Context `
+                -Force `
+                -Verbose:$false | Out-Null
+        }
+    }
+
+    $OptionalParameters[$ArtifactsLocationName] = $StorageAccount.Context.BlobEndPoint + $StorageContainerName
+    # Generate a 4 hour SAS token for the artifacts location if one was not provided in the parameters file
+    $StagingSasToken = New-AzStorageContainerSASToken `
+                                -Name $StorageContainerName `
+                                -Context $StorageAccount.Context `
+                                -Permission r `
+                                -ExpiryTime (Get-Date).AddHours(4)
+    $OptionalParameters[$ArtifactsLocationSasTokenName] = ConvertTo-SecureString -AsPlainText -Force $StagingSasToken
+}


### PR DESCRIPTION
Updated Cmdlets
* `Invoke-ArmTemplateDeployment` - The `ArmTemplatePath` parameter can now reference an [Azure Bicep](https://github.com/Azure/bicep/) file, also adds the `DeploymentScope` parameter to support targetting different ARM deployment scopes