### PR TITLE
Fixes Invoke-AzCliRestMethod not allowing array-based request payloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.1.3-debian-buster-slim
+FROM mcr.microsoft.com/powershell:7.1.4-debian-buster-slim
 
 # Install azure-cli
 ARG AZCLI_VER=2.22.1-1~buster
@@ -16,6 +16,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get update && apt-get -y install --no-install-recommends \
         azure-cli=${AZCLI_VER} \
         dotnet-sdk-3.1 \
+        dotnet-sdk-5.0 \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Install PowerShell Az module
@@ -28,7 +29,7 @@ RUN pwsh -noni -c "\$ProgressPreference='SilentlyContinue'; Install-Module Az.Sy
 ADD module /usr/local/share/powershell/Modules/Corvus.Deployment
 
 # Install Bicep so it is available via azure-cli and system path
-ARG AZ_BICEP_VER=v0.4.63
+ARG AZ_BICEP_VER=v0.4.613
 RUN az bicep install --version $AZ_BICEP_VER \
     && mv /root/.azure/bin/bicep /usr/local/bin/bicep \
     && chmod 755 /usr/local/bin/bicep \

--- a/module/functions/azure/Invoke-ArmTemplateDeployment.ps1
+++ b/module/functions/azure/Invoke-ArmTemplateDeployment.ps1
@@ -80,7 +80,7 @@ function Invoke-ArmTemplateDeployment
         [string] $StorageResourceGroupName = "arm-deploy-staging-$Location",
         [string] $ArtifactsLocationName = '_artifactsLocation',
         [string] $ArtifactsLocationSasTokenName = '_artifactsLocationSasToken',
-        [string] $BicepVersion = "0.4.63"
+        [string] $BicepVersion = "0.4.613"
     )
 
     $OptionalParameters = @{}

--- a/module/functions/azure/azcli/Invoke-AzCliRestCommand.Tests.ps1
+++ b/module/functions/azure/azcli/Invoke-AzCliRestCommand.Tests.ps1
@@ -1,0 +1,58 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".ps1")
+
+. "$here\$sut"
+
+# Ensure this internal function is available for mocking
+function Invoke-AzCli {}
+
+Describe "Invoke-AzCliRestCommand" {
+
+    Context "ParameterSet 'body as hashtable'" {
+
+        # Mock the call and have simply return the requested command so we can validate it in the test
+        Mock Invoke-AzCli {
+            # return the second argument, which will be the value of the '-Command' parameter
+            return $args[1]
+        }
+
+        $commonParams = @{
+            Uri = "https://foo.com/bar"
+            Method = "POST"
+        }
+        $escapedHeaders = '{\"Content-Type\": \"application/json\"}'
+
+        $expectedResponseFormatString = "rest --uri 'https://foo.com/bar' --method {1} --body '{2}' --headers '{3}'"
+
+        Context "Passing a hashtable" {
+            $res = Invoke-AzCliRestCommand @commonParams -Body @{foo="bar"}
+            It "should process the request correctly" {
+                $expected = $expectedResponseFormatString -f $commonParams.Uri,
+                                                             $commonParams.Method,
+                                                             '{\"foo\": \"bar\"}',
+                                                             $escapedHeaders
+                $res | Should Be $expected
+            }
+        }
+        Context "Passing an array of hashtables" {
+            $res = Invoke-AzCliRestCommand @commonParams -Body @(@{foo="bar"},@{bar="foo"})
+            It "should process the request correctly" {
+                $expected = $expectedResponseFormatString -f $commonParams.Uri,
+                                                             $commonParams.Method,
+                                                             '[{\"foo\": \"bar\"},{\"bar\": \"foo\"}]',
+                                                             $escapedHeaders
+                $res | Should Be $expected
+            }
+        }
+        Context "Passing a string" {
+            It "should throw an expception" {
+                { Invoke-AzCliRestCommand @commonParams -Body "foo" } | Should -Throw "The -Body parameter must be of type [hashtable] or [hashtable[]]"
+            }
+        }
+        Context "Passing a string array" {
+            It "should throw an expception" {
+                { Invoke-AzCliRestCommand @commonParams -Body @("foo","bar") } | Should -Throw "The -Body parameter must be of type [hashtable] or [hashtable[]]"
+            }
+        }
+    }
+}

--- a/module/functions/azure/azcli/Invoke-AzCliRestCommand.ps1
+++ b/module/functions/azure/azcli/Invoke-AzCliRestCommand.ps1
@@ -16,7 +16,7 @@ The Uri of the request to be invoked.
 The REST method of the request to be invoked.
 
 .PARAMETER Body
-The body of the request to be invoked.
+The body of the request to be invoked, represented as a hashtable or an array of hashtables.
 
 .PARAMETER BodyFilePath
 The path to the file containing the body of the request to be invoked.
@@ -50,7 +50,7 @@ function Invoke-AzCliRestCommand
         [string] $Method = "GET",
         
         [Parameter(ParameterSetName = 'Body as hashtable')]
-        [hashtable] $Body,
+        $Body,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'Body as file')]
         [string] $BodyFilePath,

--- a/module/functions/azure/azcli/Invoke-AzCliRestCommand.ps1
+++ b/module/functions/azure/azcli/Invoke-AzCliRestCommand.ps1
@@ -87,7 +87,12 @@ function Invoke-AzCliRestCommand
     if (@("PUT", "POST", "PATCH") -contains $Method) {
         switch ($PSCmdlet.ParameterSetName) {
             "Body as hashtable" {
-                $bodyAsJson = (ConvertTo-Json $Body -Depth 30 -Compress).replace('"', '\"').replace(':\', ': \').replace("'", "''")
+                if ($Body -is [hashtable] -or ($Body -is [array] -and $Body[0] -is [hashtable])) {
+                    $bodyAsJson = (ConvertTo-Json $Body -Depth 100 -Compress).replace('"', '\"').replace(':\', ': \').replace("'", "''")
+                }
+                else {
+                    throw "The -Body parameter must be of type [hashtable] or [hashtable[]]"
+                }
                 break
             }
             "Body as file" {


### PR DESCRIPTION
Updated Cmdlets

* `Invoke-AzCliRestMethod` - The `-Body` parameter is no longer restricted to being a `hashtable` type, so array-based request payloads are now supported
* `Invoke-ArmTemplateDeployment` - Default version of Bicep updated to v0.4.613

Updates the Docker image:
* Adds support for .Net 5.0 global tools
* Updates to PowerShell 7.1.4
* Updates to Bicep 0.4.613
* Latest Debian updates as of 23/09/2021

