### PR TITLE
Fix issue with 'Invoke-AzCli' error handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/powershell:7.1.4-debian-buster-slim
 
 # Install azure-cli
-ARG AZCLI_VER=2.22.1-1~buster
+ARG AZCLI_VER=2.29.1-1~buster
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y upgrade \
     && apt-get -y install --no-install-recommends ca-certificates curl apt-transport-https lsb-release gnupg wget \
@@ -20,9 +20,9 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Install PowerShell Az module
-ARG AZ_PWSH_VER=5.9.0
-RUN pwsh -noni -c "\$ProgressPreference='SilentlyContinue'; Install-Module Az -AllowClobber -RequiredVersion '${AZ_PWSH_VER}' -Repository PSGallery -Force -Scope AllUsers"
-ARG AZ_SYNAPSE_VER=0.8.0
+ARG AZ_PWSH_VER=6.5.0
+RUN pwsh -noni -c "\$ProgressPreference='SilentlyContinue'; Install-Module Az -AllowClobber -RequiredVersion '${AZ_PWSH_VER}' -Repository PSGallery -Force -Scope AllUsers -Verbose"
+ARG AZ_SYNAPSE_VER=0.17.0
 RUN pwsh -noni -c "\$ProgressPreference='SilentlyContinue'; Install-Module Az.Synapse -AllowClobber -RequiredVersion '${AZ_SYNAPSE_VER}' -Repository PSGallery -Force -Scope AllUsers"
 
 # Install Corvus.Deployment module

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/powershell:7.1.4-debian-buster-slim
 
 # Install azure-cli
-ARG AZCLI_VER=2.29.1-1~buster
+ARG AZCLI_VER=2.22.1-1~buster
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y upgrade \
     && apt-get -y install --no-install-recommends ca-certificates curl apt-transport-https lsb-release gnupg wget \
@@ -20,9 +20,9 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Install PowerShell Az module
-ARG AZ_PWSH_VER=6.5.0
-RUN pwsh -noni -c "\$ProgressPreference='SilentlyContinue'; Install-Module Az -AllowClobber -RequiredVersion '${AZ_PWSH_VER}' -Repository PSGallery -Force -Scope AllUsers -Verbose"
-ARG AZ_SYNAPSE_VER=0.17.0
+ARG AZ_PWSH_VER=5.9.0
+RUN pwsh -noni -c "\$ProgressPreference='SilentlyContinue'; Install-Module Az -AllowClobber -RequiredVersion '${AZ_PWSH_VER}' -Repository PSGallery -Force -Scope AllUsers"
+ARG AZ_SYNAPSE_VER=0.8.0
 RUN pwsh -noni -c "\$ProgressPreference='SilentlyContinue'; Install-Module Az.Synapse -AllowClobber -RequiredVersion '${AZ_SYNAPSE_VER}' -Repository PSGallery -Force -Scope AllUsers"
 
 # Install Corvus.Deployment module


### PR DESCRIPTION
Updated Cmdlets:
* `Invoke-AzCli` - Updated to workaround a behaviour change/bug in PowerShell `7.2.0` where `-ErrorVariable` does not capture messages sent to standard error stream.