### PR TITLE
Added 'CompatiblePSEditions' to module manifest

### DIFF
--- a/module/Corvus.Deployment.psd1
+++ b/module/Corvus.Deployment.psd1
@@ -10,7 +10,7 @@ RootModule = 'Corvus.Deployment.psm1'
 ModuleVersion = '0.0.0'
 
 # Supported PSEditions
-# CompatiblePSEditions = @()
+CompatiblePSEditions = @('Core')
 
 # ID used to uniquely identify this module
 GUID = '6d1b76e8-dd99-4db2-a49f-588d7f259a2c'


### PR DESCRIPTION
The module already requires language version 6 or greater, however, this doesn't block the installation of the module on Windows PowerShell (i.e. v5.1) - it just prevents it from being imported and makes it invisible to `Get-Module`, which doesn't help diagnosing this scenario.

This change should ensure that attempts to install the module on older versions of PowerShell are explicitly blocked.

Technically this a breaking change, though the module would never have been usable on such versions of PowerShell that are now explcitly blocked.