### PR TITLE
Add key vault support to 'Assert-AzureServicePrincipalForRbac'

### DIFF
--- a/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
+++ b/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
@@ -20,6 +20,9 @@ The key vault where that service principal password will be stored.
 .PARAMETER KeyVaultSecretName
 The key vault secret name that service principal password will be stored in.
 
+.PARAMETER RotateSecret
+When specified, the service principal secret will be regenerated.
+
 .OUTPUTS
 Returns a tuple containing a hashtable representing the object describing the Azure AD service principal and
 it's client secret. Where the client secret is not avilable (e.g. the service principal aleady exists) or the 
@@ -46,11 +49,47 @@ function Assert-AzureServicePrincipalForRbac
 
         [Parameter(ParameterSetName = 'KeyVault',
                     Mandatory = $true)]
-        [string] $KeyVaultSecretName
+        [string] $KeyVaultSecretName,
 
+        [Parameter(ParameterSetName = 'KeyVault')]
+        [switch] $RotateSecret
     )
 
+    #region internal helper functions
+    function _handleCredential {
+        [CmdletBinding()]
+        param (
+            [Parameter(Mandatory=$true)]
+            $ServicePrincipal
+        )
+
+        # Generate a service principal secret
+        $spCred = $ServicePrincipal | New-AzADServicePrincipalCredential
+
+        # get the secret from the credential object, based on which graph API we're using
+        $spCredential = $useMsGraph `
+                                ? ($spCred.SecretText | ConvertTo-SecureString -AsPlainText -Force) `
+                                : $spCred.Secret
+
+        if ($useKeyVault) {
+            Write-Host "Storing service principal secret in key vault [VaultName=$KeyVaultName, SecretName=$KeyVaultSecretName]"
+            Set-AzKeyVaultSecret -VaultName $KeyVaultName `
+                                -Name $KeyVaultSecretName `
+                                -SecretValue $spCredential `
+                                -ContentType "text/plain" `
+                | Out-Null
+
+            return $null
+        }
+        else {
+            return (ConvertFrom-SecureString $spCredential -AsPlainText)
+        }
+    }
+    #endregion
+
     _EnsureAzureConnection -AzPowerShell | Out-Null
+
+    $useKeyVault = ($PSCmdlet.ParameterSetName -eq "KeyVault")
 
     # Handle Azure Graph -> MS Graph transition
     # Breaking change to property names between v4 and v5 of the module
@@ -80,36 +119,28 @@ function Assert-AzureServicePrincipalForRbac
                 $createParams += @{ SkipAssignment = $true }
             }
             $newSp = New-AzADServicePrincipal @createParams
-            Write-Host ("Complete - ObjectId={0},ApplicationId={1}" -f $newSp.Id, $newSp.$appIdPropertyName)
+            Write-Host ("Created service principal [ObjectId={0}, ApplicationId={1}]" -f $newSp.Id, $newSp.$appIdPropertyName)
 
-            if ($useMsGraph) {
-                $spCredential = $newSp.PasswordCredentials.SecretText | ConvertTo-SecureString -AsPlainText -Force
-            }
-            else {
-                $spCredential = $newSp.Secret
-            }
-            
-            # Do the required credential handling
-            if ($PSCmdlet.ParameterSetName -eq "KeyVault") {
-                # Store the secret in key vault
-                Write-Host "Storing service principal secret in key vault '$KeyVaultName' as the secret '$KeyVaultSecretName'"
-                Set-AzKeyVaultSecret -VaultName $KeyVaultName `
-                                     -Name $KeyVaultSecretName `
-                                     -SecretValue $spCredential `
-                                     -ContentType "text/plain" `
-                    | Out-Null
-            }
-            else {
-                # retain previous behaviour of simply returning the password
-                $spSecret = ConvertFrom-SecureString $spCredential -AsPlainText
-            }
+            $spSecret = _handleCredential $newSp
         }
     }
     else {
-        Write-Host ("Service Principal '{0}' already exists - skipping [ObjectId={1},ApplicationId={2}]" -f `
+        Write-Host ("Service Principal '{0}' already exists [ObjectId={1}, ApplicationId={2}]" -f `
                             $Name,
                             $existingSp.Id,
                             $existingSp.$appIdPropertyName)
+
+        if ($useKeyVault) {
+            # if using key vault, check whether the specified secret is available
+            $existingSecret = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $KeyVaultSecretName
+        }
+
+        if (($useKeyVault -and !$existingSecret) -or $RotateSecret) {
+            if ($PSCmdlet.ShouldProcess($Name, "Rotate Service Principal Secret")) {
+                Write-Host "Rotating service principal credential [UseKeyVault=$useKeyVault, KeyVaultSecretMissing=$(!$existingSecret), RotateFlag=$RotateSecret]"
+                $spSecret = _handleCredential $existingSp
+            }
+        }
     }
 
     return ($existingSp ? $existingSp : $newSp),$spSecret

--- a/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
+++ b/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
@@ -85,7 +85,7 @@ function Assert-AzureServicePrincipalForRbac
             Set-AzKeyVaultSecret -VaultName $KeyVaultName `
                                  -Name $KeyVaultSecretName `
                                  -SecretValue ($spLoginDetails | ConvertTo-Json | ConvertTo-SecureString -AsPlainText -Force) `
-                                 -ContentType "text/plain" `
+                                 -ContentType "application/json" `
                 | Out-Null
 
             return $null


### PR DESCRIPTION
Updated Cmdlets:

* `Assert-AzureServicePrincipalForRbac` - Added support for storing the service principal password in a Key Vault, also now uses Azure PowerShell instead of Azure CLI
* `Invoke-ArmTemplateDeployment` - Retries are now configurable, added `-WhatIf` support
