### PR TITLE
AzureAD updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,15 +24,15 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 ARG AZ_PWSH_VER=7.3.2
 RUN pwsh -noni -c "\$ProgressPreference='SilentlyContinue'; Install-Module Az -AllowClobber -RequiredVersion '${AZ_PWSH_VER}' -Repository PSGallery -Force -Scope AllUsers -Verbose"
 
-# Install Corvus.Deployment module
-ADD module /usr/local/share/powershell/Modules/Corvus.Deployment
-
 # Install Bicep so it is available via azure-cli and system path
 ARG AZ_BICEP_VER=v0.5.6
 RUN az bicep install --version $AZ_BICEP_VER \
     && mv /root/.azure/bin/bicep /usr/local/bin/bicep \
     && chmod 755 /usr/local/bin/bicep \
     && ln -s /usr/local/bin/bicep /root/.azure/bin/bicep
+
+# Install Corvus.Deployment module
+ADD module /usr/local/share/powershell/Modules/Corvus.Deployment
 
 # Default to non-root user
 RUN useradd -c 'corvus.deployment user' -m -d /home/corvus -s /bin/bash corvus

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN pwsh -noni -c "\$ProgressPreference='SilentlyContinue'; Install-Module Az -A
 ADD module /usr/local/share/powershell/Modules/Corvus.Deployment
 
 # Install Bicep so it is available via azure-cli and system path
-ARG AZ_BICEP_VER=v0.4.1318
+ARG AZ_BICEP_VER=v0.5.6
 RUN az bicep install --version $AZ_BICEP_VER \
     && mv /root/.azure/bin/bicep /usr/local/bin/bicep \
     && chmod 755 /usr/local/bin/bicep \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM mcr.microsoft.com/powershell:7.1.4-debian-buster-slim
+FROM mcr.microsoft.com/powershell:7.2.2-debian-buster-slim
 
 # Install azure-cli
-ARG AZCLI_VER=2.22.1-1~buster
+ARG AZCLI_VER=2.33.1-1~buster
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y upgrade \
     && apt-get -y install --no-install-recommends ca-certificates curl apt-transport-https lsb-release gnupg wget \
@@ -17,19 +17,18 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         azure-cli=${AZCLI_VER} \
         dotnet-sdk-3.1 \
         dotnet-sdk-5.0 \
+        dotnet-sdk-6.0 \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Install PowerShell Az module
-ARG AZ_PWSH_VER=5.9.0
-RUN pwsh -noni -c "\$ProgressPreference='SilentlyContinue'; Install-Module Az -AllowClobber -RequiredVersion '${AZ_PWSH_VER}' -Repository PSGallery -Force -Scope AllUsers"
-ARG AZ_SYNAPSE_VER=0.8.0
-RUN pwsh -noni -c "\$ProgressPreference='SilentlyContinue'; Install-Module Az.Synapse -AllowClobber -RequiredVersion '${AZ_SYNAPSE_VER}' -Repository PSGallery -Force -Scope AllUsers"
+ARG AZ_PWSH_VER=7.3.2
+RUN pwsh -noni -c "\$ProgressPreference='SilentlyContinue'; Install-Module Az -AllowClobber -RequiredVersion '${AZ_PWSH_VER}' -Repository PSGallery -Force -Scope AllUsers -Verbose"
 
 # Install Corvus.Deployment module
 ADD module /usr/local/share/powershell/Modules/Corvus.Deployment
 
 # Install Bicep so it is available via azure-cli and system path
-ARG AZ_BICEP_VER=v0.4.613
+ARG AZ_BICEP_VER=v0.4.1318
 RUN az bicep install --version $AZ_BICEP_VER \
     && mv /root/.azure/bin/bicep /usr/local/bin/bicep \
     && chmod 755 /usr/local/bin/bicep \

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -20,5 +20,5 @@ branches:
     - feature
     - support
     - hotfix
-next-version: "0.3"
+next-version: "0.4"
 

--- a/module/functions/New-Password.ps1
+++ b/module/functions/New-Password.ps1
@@ -15,6 +15,12 @@ The length of the password to be generated.
 .PARAMETER ValidSymbols
 A character array containing the characters that will be treated as symbols when validating the password strength.
 
+.PARAMETER KeyVaultName
+The optional key vault where the password will be stored.
+
+.PARAMETER KeyVaultSecretName
+The key vault secret name where the password will be stored.
+
 .OUTPUTS
 SecureString
 
@@ -26,14 +32,25 @@ $pwd = New-Password -Length 18
 #>
 function New-Password
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName="Default")]
     param
     (
+        [Parameter(ParameterSetName="Default")]
         [ValidateRange(12, 256)]
         [int] $Length = 16,
 
+        [Parameter(ParameterSetName="Default")]
         [ValidateNotNull()]
-        [char[]] $ValidSymbols = '!@#$%^&*'.ToCharArray()
+        [char[]] $ValidSymbols = '!@#$%^&*'.ToCharArray(),
+
+        [Parameter(ParameterSetName="Default")]
+        [switch] $PassThru,
+
+        [Parameter(Mandatory=$true, ParameterSetName="UseKeyVault")]
+        [string] $KeyVaultName,
+        
+        [Parameter(Mandatory=$true, ParameterSetName="UseKeyVault")]
+        [string] $KeyVaultSecretName
     )
 
     # reference: https://gist.github.com/onlyann/00d9bb09d4b1338ffc88a213509a6caf
@@ -57,5 +74,19 @@ function New-Password
     until (($hasLowerChar + $hasUpperChar + $hasDigit + $hasSymbol) -eq 4)
     
     Write-Verbose "Password generated after $iterations iterations"
-    $password | ConvertTo-SecureString -AsPlainText
+    $securePassword = $password | ConvertTo-SecureString -AsPlainText
+    $password = $null
+
+    if ($PSCmdlet.ParameterSetName -eq "UseKeyVault") {
+        Write-Host "Storing password in key vault [VaultName=$KeyVaultName, SecretName=$KeyVaultSecretName]"
+        Set-AzKeyVaultSecret -VaultName $KeyVaultName `
+                                -Name $KeyVaultSecretName `
+                                -SecretValue $securePassword `
+                                -ContentType "text/plain" `
+            | Out-Null
+    }
+
+    if ($PassThru) {
+        $securePassword
+    }
 }

--- a/module/functions/New-Password.ps1
+++ b/module/functions/New-Password.ps1
@@ -53,6 +53,8 @@ function New-Password
         [string] $KeyVaultSecretName
     )
 
+    _EnsureAzureConnection -AzPowerShell | Out-Null
+    
     # reference: https://gist.github.com/onlyann/00d9bb09d4b1338ffc88a213509a6caf
     $characterList = 'a'..'z' + 'A'..'Z' + '0'..'9' + $ValidSymbols
     

--- a/module/functions/New-Password.ps1
+++ b/module/functions/New-Password.ps1
@@ -1,0 +1,61 @@
+# <copyright file="New-Password.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+<#
+.SYNOPSIS
+Returns a random password containing alpha-numerics and symbols.
+
+.DESCRIPTION
+Returns a cryptographically secure random-generated password containing upper-case, lower-case, numeric and symbol characters.
+
+.PARAMETER Length
+The length of the password to be generated.
+
+.PARAMETER ValidSymbols
+A character array containing the characters that will be treated as symbols when validating the password strength.
+
+.OUTPUTS
+SecureString
+
+.EXAMPLE
+
+$pwd = New-Password
+$pwd = New-Password -Length 18
+
+#>
+function New-Password
+{
+    [CmdletBinding()]
+    param
+    (
+        [ValidateRange(12, 256)]
+        [int] $Length = 16,
+
+        [ValidateNotNull()]
+        [char[]] $ValidSymbols = '!@#$%^&*'.ToCharArray()
+    )
+
+    # reference: https://gist.github.com/onlyann/00d9bb09d4b1338ffc88a213509a6caf
+    $characterList = 'a'..'z' + 'A'..'Z' + '0'..'9' + $ValidSymbols
+    
+    $iterations = 0
+    do {
+        $password = ""
+        for ($i = 0; $i -lt $length; $i++) {
+            $randomIndex = [System.Security.Cryptography.RandomNumberGenerator]::GetInt32(0, $characterList.Length)
+            $password += $characterList[$randomIndex]
+        }
+
+        [int]$hasLowerChar = $password -cmatch '[a-z]'
+        [int]$hasUpperChar = $password -cmatch '[A-Z]'
+        [int]$hasDigit = $password -match '[0-9]'
+        [int]$hasSymbol = $password.IndexOfAny($ValidSymbols) -ne -1
+
+        $iterations++
+    }
+    until (($hasLowerChar + $hasUpperChar + $hasDigit + $hasSymbol) -eq 4)
+    
+    Write-Verbose "Password generated after $iterations iterations"
+    $password | ConvertTo-SecureString -AsPlainText
+}

--- a/module/functions/azure/Connect-Azure.ps1
+++ b/module/functions/azure/Connect-Azure.ps1
@@ -35,22 +35,30 @@ When true, a connection to Azure via the AzureCLI will not be initialised.
 
 function Connect-Azure
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName="Default")]
     param (
-        [Parameter(Mandatory=$true)]
+        [Parameter(ParameterSetName="Default", Mandatory=$true)]
         [guid] $SubscriptionId,
 
         [Parameter(Mandatory=$true)]
         [guid] $AadTenantId,
 
         [switch] $SkipAzPowerShell,
-        [switch] $SkipAzureCli
+        [switch] $SkipAzureCli,
+
+        [Parameter(ParameterSetName="NoSubscriptions")]
+        [switch] $TenantOnly
     )
     
     # NOTE: This function is exempt from the test requiring consumers of AzPowerShell to call _EnsureAzureConnection
 
-    $script:moduleContext.SubscriptionId = $SubscriptionId
+    $script:moduleContext.TenantOnly = $TenantOnly
+    $script:moduleContext.SubscriptionId = $script:moduleContext.NoSubscriptions ? "" : $SubscriptionId
     $script:moduleContext.AadTenantId = $AadTenantId
+
+    if ($script:moduleContext.TenantOnly) {
+        Write-Host "Connecting with 'TenantOnly' option"
+    }
 
     # Attempt to detect if we're running interactively
     $isInteractive = [Environment]::UserInteractive -and !(Test-Path env:\SYSTEM_TEAMFOUNDATIONSERVERURI)
@@ -61,11 +69,19 @@ function Connect-Azure
         $ctx = Get-AzContext
         if (!$ctx -and $isInteractive) {
             Write-Host "Not currently logged-in to Az PowerShell - triggering manual login"
-            Connect-AzAccount -SubscriptionId $SubscriptionId -TenantId $AadTenantId | Out-Null
+            $connectSplat = @{
+                TenantId = $AadTenantId
+            }
+            if (!$TenantOnly) {
+                $connectSplat += @{
+                    SubscriptionId = $SubscriptionId
+                }
+            }
+            Connect-AzAccount @connectSplat | Out-Null
         }
         elseif ($ctx -and `
                     $ctx.Tenant.Id -eq $AadTenantId -and `
-                    $ctx.Subscription.Id -ne $SubscriptionId
+                    (!$TenantOnly -and $ctx.Subscription.Id -ne $script:moduleContext.SubscriptionId)
         ) {
             # Try to switch to the required subscription, if we are connected to the right tenant.
             # This avoids an unnecessary validation failure when we're connected to the right tenant,
@@ -73,7 +89,7 @@ function Connect-Azure
             Set-AzContext -SubscriptionId $SubscriptionId | Out-Null
         }
 
-        if (!(_ValidateAzureConnectionDetails -SubscriptionId $SubscriptionId -AadTenantId $AadTenantId -AzPowerShell)) {
+        if (!(_ValidateAzureConnectionDetails -SubscriptionId $script:moduleContext.SubscriptionId -AadTenantId $AadTenantId -AzPowerShell -TenantOnly:$TenantOnly)) {
             Write-Error "The current Az PowerShell connection context does not match the specified details"
         }
         else {
@@ -83,9 +99,18 @@ function Connect-Azure
 
     if (-not $SkipAzureCli) {
         Write-Host "Validating AzureCLI connection"
-        Assert-AzCliLogin -SubscriptionId $SubscriptionId -AadTenantId $AadTenantId | Out-Null
+        $splat = @{
+            AadTenantId = $AadTenantId
+        }
+        if ($TenantOnly) {
+            $splat += @{ TenantOnly = $TenantOnly }
+        }
+        else {
+            $splat += @{ SubscriptionId = $script:moduleContext.SubscriptionId }
+        }
+        Assert-AzCliLogin @splat | Out-Null
         
-        if (!(_ValidateAzureConnectionDetails -SubscriptionId $SubscriptionId -AadTenantId $AadTenantId -AzureCli)) {
+        if (!(_ValidateAzureConnectionDetails -SubscriptionId $script:moduleContext.SubscriptionId -AadTenantId $AadTenantId -AzureCli -TenantOnly:$TenantOnly)) {
             Write-Error "The current AzureCLI connection context does not match the specified details."
         }
         else {

--- a/module/functions/azure/_EnsureAzureConnection.ps1
+++ b/module/functions/azure/_EnsureAzureConnection.ps1
@@ -19,14 +19,17 @@ function _EnsureAzureConnection
         [switch] $AzPowerShell,
 
         [Parameter()]
-        [switch] $AzureCli
+        [switch] $AzureCli,
+
+        [Parameter()]
+        [switch] $TenantOnly
     )
 
     function _validateAzPowerShell
     {
         $valid = (
             $script:moduleContext.AzPowerShell.Connected -and `
-            (_ValidateAzureConnectionDetails -SubscriptionId $script:moduleContext.SubscriptionId -AadTenantId $script:moduleContext.AadTenantId -AzPowerShell)
+            (_ValidateAzureConnectionDetails -SubscriptionId $script:moduleContext.SubscriptionId -AadTenantId $script:moduleContext.AadTenantId -AzPowerShell -TenantOnly:$TenantOnly)
         )
         return $valid
 
@@ -35,7 +38,7 @@ function _EnsureAzureConnection
     {
         $valid = (
             $script:moduleContext.AzureCli.Connected -and `
-            (_ValidateAzureConnectionDetails -SubscriptionId $script:moduleContext.SubscriptionId -AadTenantId $script:moduleContext.AadTenantId -AzureCli)
+            (_ValidateAzureConnectionDetails -SubscriptionId $script:moduleContext.SubscriptionId -AadTenantId $script:moduleContext.AadTenantId -AzureCli -TenantOnly:$TenantOnly)
         )
         return $valid
     }

--- a/module/functions/azure/aad/Assert-AzureAdApiPermissions.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdApiPermissions.ps1
@@ -43,7 +43,8 @@ function Assert-AzureAdApiPermissions
         [guid] $ApplicationId
     )
 
-    _EnsureAzureConnection -AzPowerShell | Out-Null
+    # Check whether we have a valid AzPowerShell connection, but no subscription-level access is required
+    _EnsureAzureConnection -AzPowerShell -TenantOnly -ErrorAction Stop | Out-Null
     
     [hashtable[]] $accessRequirements = @()
     foreach ($permission in $ApplicationPermissions) {

--- a/module/functions/azure/aad/Assert-AzureAdApp.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdApp.ps1
@@ -35,8 +35,8 @@ function Assert-AzureAdApp
         [string[]]$ReplyUrls
     )
 
-    # Check whether we have a valid AzPowerShell connection
-    _EnsureAzureConnection -AzPowerShell -ErrorAction Stop
+    # Check whether we have a valid AzPowerShell connection, but no subscription-level access is required
+    _EnsureAzureConnection -AzPowerShell -TenantOnly -ErrorAction Stop | Out-Null
     
     Write-Host "Ensuring Azure AD application {$DisplayName} exists..."
 

--- a/module/functions/azure/aad/Assert-AzureAdAppForAppService.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdAppForAppService.ps1
@@ -31,8 +31,8 @@ function Assert-AzureAdAppForAppService
         [string] $AppId
     )
 
-    # Check whether we have a valid AzPowerShell connection
-    _EnsureAzureConnection -AzPowerShell -ErrorAction Stop
+    # Check whether we have a valid AzPowerShell connection, but no subscription-level access is required
+    _EnsureAzureConnection -AzPowerShell -TenantOnly -ErrorAction Stop | Out-Null
     
     if ( !(Test-AzureGraphAccess) ) {
         if (-not $AppId) {

--- a/module/functions/azure/aad/Assert-AzureAdAppRole.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdAppRole.ps1
@@ -47,8 +47,8 @@ function Assert-AzureAdAppRole
         [switch] $UseAzureAdGraph
     )
     
-    # Check whether we have a valid AzPowerShell connection
-    _EnsureAzureConnection -AzPowerShell -ErrorAction Stop
+    # Check whether we have a valid AzPowerShell connection, but no subscription-level access is required
+    _EnsureAzureConnection -AzPowerShell -TenantOnly -ErrorAction Stop | Out-Null
 
     $TenantId = $script:moduleContext.AadTenantId
 

--- a/module/functions/azure/aad/Assert-AzureAdGroupMembership.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdGroupMembership.Tests.ps1
@@ -9,7 +9,6 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".p
 # define other functions that will be mocked
 function _EnsureAzureConnection {}
 function Get-AzADGroup {}
-function Get-AzADGroupMember {}
 function Add-AzADGroupMember { param([string[]] $MemberObjectId) }
 function Remove-AzADGroupMember { param([string[]] $MemberObjectId) }
 
@@ -62,7 +61,7 @@ Describe "Assert-AzureAdGroupMembership Tests" {
     Context "Required members are already in the group (one member)" {
 
         Mock Get-AzADGroup { $mockGroup }
-        Mock Get-AzADGroupMember { $mockGroupMembers[0] }
+        Mock _getGroupMembers { $mockGroupMembers[0] }
         Mock Get-AzureAdDirectoryObject { $mockGroupMembers[0] }
         Mock Add-AzADGroupMember {}
         Mock Remove-AzADGroupMember {}
@@ -81,7 +80,7 @@ Describe "Assert-AzureAdGroupMembership Tests" {
     Context "Required members are already in the group (multiple members)" {
 
         Mock Get-AzADGroup { $mockGroup }
-        Mock Get-AzADGroupMember { $mockGroupMembers }
+        Mock _getGroupMembers { $mockGroupMembers }
         Mock Get-AzureAdDirectoryObject { $mockGroupMembers[0] } -ParameterFilter { $Criterion -eq $mockGroupMembers[0].Id }
         Mock Get-AzureAdDirectoryObject { $mockGroupMembers[1] } -ParameterFilter { $Criterion -eq $mockGroupMembers[1].Id }
         Mock Add-AzADGroupMember {}
@@ -101,7 +100,7 @@ Describe "Assert-AzureAdGroupMembership Tests" {
     Context "Missing single member" {
 
         Mock Get-AzADGroup { $mockGroup }
-        Mock Get-AzADGroupMember { $mockGroupMembers[0] }
+        Mock _getGroupMembers { $mockGroupMembers[0] }
         Mock Get-AzureAdDirectoryObject { $mockGroupMembers[0] } -ParameterFilter { $Criterion -eq $mockGroupMembers[0].Id }
         Mock Get-AzureAdDirectoryObject { $mockGroupMembers[1] } -ParameterFilter { $Criterion -eq $mockGroupMembers[1].Id }
         Mock Add-AzADGroupMember {}
@@ -121,7 +120,7 @@ Describe "Assert-AzureAdGroupMembership Tests" {
     Context "Missing multiple members" {
 
         Mock Get-AzADGroup { $mockGroup }
-        Mock Get-AzADGroupMember { @() }
+        Mock _getGroupMembers { @() }
         Mock Get-AzureAdDirectoryObject { $mockGroupMembers[0] } -ParameterFilter { $Criterion -eq $mockGroupMembers[0].Id }
         Mock Get-AzureAdDirectoryObject { $mockGroupMembers[1] } -ParameterFilter { $Criterion -eq $mockGroupMembers[1].Id }
         Mock Add-AzADGroupMember {}
@@ -142,7 +141,7 @@ Describe "Assert-AzureAdGroupMembership Tests" {
     Context "Additional members are already in the group (Non-Strict)" {
 
         Mock Get-AzADGroup { $mockGroup }
-        Mock Get-AzADGroupMember { $mockGroupMembers }
+        Mock _getGroupMembers { $mockGroupMembers }
         Mock Get-AzureAdDirectoryObject { $mockGroupMembers[0] }
         Mock Add-AzADGroupMember {}
         Mock Remove-AzADGroupMember {}
@@ -160,7 +159,7 @@ Describe "Assert-AzureAdGroupMembership Tests" {
     Context "Additional members are already in the group (Strict)" {
 
         Mock Get-AzADGroup { $mockGroup }
-        Mock Get-AzADGroupMember { $mockGroupMembers }
+        Mock _getGroupMembers { $mockGroupMembers }
         Mock Get-AzureAdDirectoryObject { $mockGroupMembers[0] }
         Mock Add-AzADGroupMember {}
         Mock Remove-AzADGroupMember {}
@@ -182,7 +181,7 @@ Describe "Assert-AzureAdGroupMembership Tests" {
         $requiredMembers = $mockGroupMembers
 
         Mock Get-AzADGroup { $mockGroup }
-        Mock Get-AzADGroupMember { @($mockExistingMembers[0], $mockExistingMembers[2]) }
+        Mock _getGroupMembers { @($mockExistingMembers[0], $mockExistingMembers[2]) }
         Mock Get-AzureAdDirectoryObject { $mockExistingMembers[0] } -ParameterFilter { $Criterion -eq $mockExistingMembers[0].Id }
         Mock Get-AzureAdDirectoryObject { $mockExistingMembers[1] } -ParameterFilter { $Criterion -eq $mockExistingMembers[1].Id }
         Mock Get-AzureAdDirectoryObject { $mockExistingMembers[2] } -ParameterFilter { $Criterion -eq $mockExistingMembers[2].Id }
@@ -205,7 +204,7 @@ Describe "Assert-AzureAdGroupMembership Tests" {
 
     Context "Adding an invalid member" {
         Mock Get-AzADGroup { $mockGroup }
-        Mock Get-AzADGroupMember { @() }
+        Mock _getGroupMembers { @() }
         Mock Get-AzureAdDirectoryObject {} -ParameterFilter { $Criterion -eq [guid]::Empty }
         Mock Add-AzADGroupMember {}
         Mock Remove-AzADGroupMember {}

--- a/module/functions/azure/aad/Assert-AzureAdGroupMembership.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdGroupMembership.Tests.ps1
@@ -3,8 +3,13 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".p
 
 . "$here\$sut"
 
+# import other module functions
+. "$here\Get-AzureAdDirectoryObject.ps1"
+
 # define other functions that will be mocked
 function _EnsureAzureConnection {}
+# declare the Azure PowerShell dependencies
+function Get-AzADGroup {}   # workaround for environment issue with GitHub build server
 
 Describe "Assert-AzureAdGroupMembership Tests" {
 

--- a/module/functions/azure/aad/Assert-AzureAdGroupMembership.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdGroupMembership.Tests.ps1
@@ -8,8 +8,10 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".p
 
 # define other functions that will be mocked
 function _EnsureAzureConnection {}
-# declare the Azure PowerShell dependencies
-function Get-AzADGroup {}   # workaround for environment issue with GitHub build server
+function Get-AzADGroup {}
+function Get-AzADGroupMember {}
+function Add-AzADGroupMember { param([string[]] $MemberObjectId) }
+function Remove-AzADGroupMember { param([string[]] $MemberObjectId) }
 
 Describe "Assert-AzureAdGroupMembership Tests" {
 

--- a/module/functions/azure/aad/Assert-AzureAdGroupMembership.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdGroupMembership.Tests.ps1
@@ -3,10 +3,12 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".p
 
 . "$here\$sut"
 
-# Import other module dependendencies
-# . "$here\..\..\Select-ExceptIn.ps1"
+# define other functions that will be mocked
+function _EnsureAzureConnection {}
 
 Describe "Assert-AzureAdGroupMembership Tests" {
+
+    Mock _EnsureAzureConnection { $true }
 
     $mockDuplicateGroups = @(
         @{Id="00000000-0000-0000-0000-000000000000"; DisplayName="fakeGroup1"; SecurityEnabled=$true}

--- a/module/functions/azure/aad/Assert-AzureAdGroupMembership.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdGroupMembership.Tests.ps1
@@ -17,8 +17,8 @@ Describe "Assert-AzureAdGroupMembership Tests" {
     Mock _EnsureAzureConnection { $true }
 
     $mockDuplicateGroups = @(
-        @{Id="00000000-0000-0000-0000-000000000000"; DisplayName="fakeGroup1"; SecurityEnabled=$true}
-        @{Id="11111111-1111-1111-1111-111111111111"; DisplayName="fakeGroup2"; SecurityEnabled=$true}
+        @{Id="00000000-0000-0000-0000-000000000000"; DisplayName="a-common-group-name"; SecurityEnabled=$true}
+        @{Id="11111111-1111-1111-1111-111111111111"; DisplayName="a-common-group-name"; SecurityEnabled=$true}
     )
 
     $mockGroup = @{

--- a/module/functions/azure/aad/Assert-AzureAdGroupMembership.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdGroupMembership.Tests.ps1
@@ -1,0 +1,216 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".ps1")
+
+. "$here\$sut"
+
+# Import other module dependendencies
+# . "$here\..\..\Select-ExceptIn.ps1"
+
+Describe "Assert-AzureAdGroupMembership Tests" {
+
+    $mockDuplicateGroups = @(
+        @{Id="00000000-0000-0000-0000-000000000000"; DisplayName="fakeGroup1"; SecurityEnabled=$true}
+        @{Id="11111111-1111-1111-1111-111111111111"; DisplayName="fakeGroup2"; SecurityEnabled=$true}
+    )
+
+    $mockGroup = @{
+        Id = "7c408c06-b467-4fd5-96e2-bc9cbc1bd4ee"
+        DisplayName = "some-group"
+        SecurityEnabled = $true
+    }
+    $mockGroupMembers = @(
+        @{Id = "6cea30de-a493-42b7-9855-2d9a343eca8f"}
+        @{Id = "9871e647-e493-4596-84d7-8bbbe8e90447"}
+    )
+
+    Context "Group does not exist" {
+
+        Mock Get-AzADGroup {}
+        Mock Get-AzureAdDirectoryObject {}
+
+        It "should throw an exception" {
+            $mockGroupName = "nonexistent-group"
+            { Assert-AzureAdGroupMembership -Name $mockGroupName -RequiredMembers @("user@nowwhere.org") } |
+                Should -Throw "The specified group could not be found: DisplayName=$mockGroupName"
+
+            Assert-MockCalled Get-AzureAdDirectoryObject -Times 0
+        }
+    }
+
+    Context "Multiple groups found" {
+
+        Mock Get-AzADGroup { $mockDuplicateGroups }
+        Mock Get-AzureAdDirectoryObject {}
+
+        It "should throw an exception" {
+            { Assert-AzureAdGroupMembership -Name "a-common-group-name" -RequiredMembers @("user@nowwhere.org") } | 
+                Should -Throw "Found multiple matching groups: ObjectId=$($mockDuplicateGroups[0].Id); ObjectId=$($mockDuplicateGroups[1].Id);"
+
+            Assert-MockCalled Get-AzureAdDirectoryObject -Times 0
+        }
+    }
+
+    Context "Required members are already in the group (one member)" {
+
+        Mock Get-AzADGroup { $mockGroup }
+        Mock Get-AzADGroupMember { $mockGroupMembers[0] }
+        Mock Get-AzureAdDirectoryObject { $mockGroupMembers[0] }
+        Mock Add-AzADGroupMember {}
+        Mock Remove-AzADGroupMember {}
+
+        Assert-AzureAdGroupMembership `
+            -Name $mockGroup.DisplayName `
+            -RequiredMembers @($mockGroupMembers[0].Id)
+
+        It "should not try to update the group" {
+            Assert-MockCalled Get-AzureAdDirectoryObject -Times 1
+            Assert-MockCalled Add-AzADGroupMember -Times 0
+            Assert-MockCalled Remove-AzADGroupMember -Times 0
+        }
+    }
+
+    Context "Required members are already in the group (multiple members)" {
+
+        Mock Get-AzADGroup { $mockGroup }
+        Mock Get-AzADGroupMember { $mockGroupMembers }
+        Mock Get-AzureAdDirectoryObject { $mockGroupMembers[0] } -ParameterFilter { $Criterion -eq $mockGroupMembers[0].Id }
+        Mock Get-AzureAdDirectoryObject { $mockGroupMembers[1] } -ParameterFilter { $Criterion -eq $mockGroupMembers[1].Id }
+        Mock Add-AzADGroupMember {}
+        Mock Remove-AzADGroupMember {}
+
+        Assert-AzureAdGroupMembership `
+            -Name $mockGroup.DisplayName `
+            -RequiredMembers ($mockGroupMembers | Select-Object -ExpandProperty Id)
+
+        It "should not try to update the group" {
+            Assert-MockCalled Get-AzureAdDirectoryObject -Times 2
+            Assert-MockCalled Add-AzADGroupMember -Times 0
+            Assert-MockCalled Remove-AzADGroupMember -Times 0
+        }
+    }
+
+    Context "Missing single member" {
+
+        Mock Get-AzADGroup { $mockGroup }
+        Mock Get-AzADGroupMember { $mockGroupMembers[0] }
+        Mock Get-AzureAdDirectoryObject { $mockGroupMembers[0] } -ParameterFilter { $Criterion -eq $mockGroupMembers[0].Id }
+        Mock Get-AzureAdDirectoryObject { $mockGroupMembers[1] } -ParameterFilter { $Criterion -eq $mockGroupMembers[1].Id }
+        Mock Add-AzADGroupMember {}
+        Mock Remove-AzADGroupMember {}
+
+        Assert-AzureAdGroupMembership `
+            -Name $mockGroup.DisplayName `
+            -RequiredMembers ($mockGroupMembers | Select-Object -ExpandProperty Id)
+
+        It "should add the missing member to the group" {
+            Assert-MockCalled Get-AzureAdDirectoryObject -Times 2
+            Assert-MockCalled Add-AzADGroupMember -Times 1 -ParameterFilter { $MemberObjectId -eq $mockGroupMembers[1].Id }
+            Assert-MockCalled Remove-AzADGroupMember -Times 0
+        }
+    }
+
+    Context "Missing multiple members" {
+
+        Mock Get-AzADGroup { $mockGroup }
+        Mock Get-AzADGroupMember { @() }
+        Mock Get-AzureAdDirectoryObject { $mockGroupMembers[0] } -ParameterFilter { $Criterion -eq $mockGroupMembers[0].Id }
+        Mock Get-AzureAdDirectoryObject { $mockGroupMembers[1] } -ParameterFilter { $Criterion -eq $mockGroupMembers[1].Id }
+        Mock Add-AzADGroupMember {}
+        Mock Remove-AzADGroupMember {}
+
+        Assert-AzureAdGroupMembership `
+            -Name $mockGroup.DisplayName `
+            -RequiredMembers ($mockGroupMembers | Select-Object -ExpandProperty Id)
+
+        It "should add the missing member to the group" {
+            Assert-MockCalled Get-AzureAdDirectoryObject -Times 2
+            Assert-MockCalled Add-AzADGroupMember -Times 1 -ParameterFilter { $MemberObjectId -eq $mockGroupMembers[0].Id }
+            Assert-MockCalled Add-AzADGroupMember -Times 1 -ParameterFilter { $MemberObjectId -eq $mockGroupMembers[1].Id }
+            Assert-MockCalled Remove-AzADGroupMember -Times 0
+        }
+    }
+
+    Context "Additional members are already in the group (Non-Strict)" {
+
+        Mock Get-AzADGroup { $mockGroup }
+        Mock Get-AzADGroupMember { $mockGroupMembers }
+        Mock Get-AzureAdDirectoryObject { $mockGroupMembers[0] }
+        Mock Add-AzADGroupMember {}
+        Mock Remove-AzADGroupMember {}
+
+        Assert-AzureAdGroupMembership `
+            -Name $mockGroup.DisplayName `
+            -RequiredMembers @($mockGroupMembers[0].Id)
+
+        It "should not try to update the group" {
+            Assert-MockCalled Add-AzADGroupMember -Times 0
+            Assert-MockCalled Remove-AzADGroupMember -Times 0
+        }
+    }
+
+    Context "Additional members are already in the group (Strict)" {
+
+        Mock Get-AzADGroup { $mockGroup }
+        Mock Get-AzADGroupMember { $mockGroupMembers }
+        Mock Get-AzureAdDirectoryObject { $mockGroupMembers[0] }
+        Mock Add-AzADGroupMember {}
+        Mock Remove-AzADGroupMember {}
+
+        Assert-AzureAdGroupMembership `
+            -Name "nonexistent-group" `
+            -RequiredMembers @($mockGroupMembers[0].Id) `
+            -StrictMode $true
+
+        It "should remove extraneous members" {
+            Assert-MockCalled Add-AzADGroupMember -Times 0
+            Assert-MockCalled Remove-AzADGroupMember -Times 1 -ParameterFilter { $MemberObjectId -eq $mockGroupMembers[1].Id }
+        }
+    }
+
+    Context "Adding and removing group members (Strict)" {
+
+        $mockExistingMembers = $mockGroupMembers + @{Id = ([guid]::Empty).Guid.ToString()}
+        $requiredMembers = $mockGroupMembers
+
+        Mock Get-AzADGroup { $mockGroup }
+        Mock Get-AzADGroupMember { @($mockExistingMembers[0], $mockExistingMembers[2]) }
+        Mock Get-AzureAdDirectoryObject { $mockExistingMembers[0] } -ParameterFilter { $Criterion -eq $mockExistingMembers[0].Id }
+        Mock Get-AzureAdDirectoryObject { $mockExistingMembers[1] } -ParameterFilter { $Criterion -eq $mockExistingMembers[1].Id }
+        Mock Get-AzureAdDirectoryObject { $mockExistingMembers[2] } -ParameterFilter { $Criterion -eq $mockExistingMembers[2].Id }
+        # We need to return a group this time, so we still have a group object for the subsequent call Remove-AzADGroupMember
+        Mock Add-AzADGroupMember { $mockGroup }
+        Mock Remove-AzADGroupMember {}
+
+        Assert-AzureAdGroupMembership `
+            -Name $mockGroup.DisplayName `
+            -RequiredMembers ($requiredMembers | Select-Object -ExpandProperty Id) `
+            -StrictMode $true
+
+        It "should remove extraneous members" {
+            Assert-MockCalled Get-AzureAdDirectoryObject -Times 1 -ParameterFilter { $Criterion -eq $mockExistingMembers[0].Id }
+            Assert-MockCalled Get-AzureAdDirectoryObject -Times 1 -ParameterFilter { $Criterion -eq $mockExistingMembers[1].Id }
+            Assert-MockCalled Add-AzADGroupMember -Times 1 -ParameterFilter { $MemberObjectId -eq $mockExistingMembers[1].Id }
+            Assert-MockCalled Remove-AzADGroupMember -Times 1 -ParameterFilter { $MemberObjectId -eq $mockExistingMembers[2].Id }
+        }
+    }
+
+    Context "Adding an invalid member" {
+        Mock Get-AzADGroup { $mockGroup }
+        Mock Get-AzADGroupMember { @() }
+        Mock Get-AzureAdDirectoryObject {} -ParameterFilter { $Criterion -eq [guid]::Empty }
+        Mock Add-AzADGroupMember {}
+        Mock Remove-AzADGroupMember {}
+        Mock Write-Warning {}
+
+        Assert-AzureAdGroupMembership `
+            -Name $mockGroup.DisplayName `
+            -RequiredMembers @([guid]::Empty)
+
+        It "should not add the member, but log a warning instead" {
+            Assert-MockCalled Get-AzureAdDirectoryObject -Times 1
+            Assert-MockCalled Add-AzADGroupMember -Times 0
+            Assert-MockCalled Remove-AzADGroupMember -Times 0
+            Assert-MockCalled Write-Warning -Times 1
+        }
+    }
+}

--- a/module/functions/azure/aad/Assert-AzureAdGroupMembership.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdGroupMembership.ps1
@@ -53,7 +53,8 @@ function Assert-AzureAdGroupMembership
         [bool] $StrictMode
     )
 
-    _EnsureAzureConnection -AzPowerShell | Out-Null
+    # Check whether we have a valid AzPowerShell connection, but no subscription-level access is required
+    _EnsureAzureConnection -AzPowerShell -TenantOnly -ErrorAction Stop | Out-Null
 
     # Setup the parameters for 'Get-AzADGroup' based on whether we've been given a group Name or ObjectId
     $groupLookupSplat = $PSCmdlet.ParameterSetName -eq "ByName" ? @{DisplayName = $Name} : @{ObjectId = $ObjectId}

--- a/module/functions/azure/aad/Assert-AzureAdGroupMembership.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdGroupMembership.ps1
@@ -53,6 +53,8 @@ function Assert-AzureAdGroupMembership
         [bool] $StrictMode
     )
 
+    _EnsureAzureConnection -AzPowerShell | Out-Null
+
     # Setup the parameters for 'Get-AzADGroup' based on whether we've been given a group Name or ObjectId
     $groupLookupSplat = $PSCmdlet.ParameterSetName -eq "ByName" ? @{DisplayName = $Name} : @{ObjectId = $ObjectId}
     [array]$group = Get-AzADGroup @groupLookupSplat | `

--- a/module/functions/azure/aad/Assert-AzureAdGroupMembership.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdGroupMembership.ps1
@@ -1,0 +1,115 @@
+# <copyright file="Assert-AzureAdGroupMembership.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+<#
+.SYNOPSIS
+Configures the membership of an AzureAD group.
+
+.DESCRIPTION
+Uses Azure PowerShell to manage AzureAD group membership.
+
+.PARAMETER Name
+The display name of the group.
+
+.PARAMETER ObjectId
+The objectId of the group.
+
+.PARAMETER Members
+The list of AzureAD objects that should be members of the group. These can be specified using
+'DisplayName', 'ObjectId', 'ApplicationId' or 'UserPrincipalName'.
+
+.PARAMETER StrictMode
+When true, existing group members not specified in the 'RequiredMembers' parameters will be removed from the group.
+
+.OUTPUTS
+AzureAD group definition object
+
+.EXAMPLE
+
+Assert-AzureAdGroupMembership -Name "MyGroup" -RequiredMembers @("MyOtherGroup", "MyUser", "MyServicePrincipal")
+Assert-AzureAdGroupMembership -Name "MyGroup" -RequiredMembers @("MyOtherGroup", "MyUser@nowhere.org", "be2a6313-cb3a-45ad-a70f-cbac2a8c565f")
+Assert-AzureAdGroupMembership -Name "MyGroup" -RequiredMembers @("f7f0545c-82b5-4008-bebf-f73fb1d5a7f8", "MyUser@nowhere.org", "be2a6313-cb3a-45ad-a70f-cbac2a8c565f")
+
+#>
+function Assert-AzureAdGroupMembership
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true, ParameterSetName="ByName")]
+        [string] $Name,
+
+        [Parameter(Mandatory=$true, ParameterSetName="ByObjectId")]
+        [string] $ObjectId,
+
+        [Parameter()]
+        [string[]] $RequiredMembers,
+
+        [Parameter()]
+        [ValidateSet("Security","Distribution")]
+        [string] $GroupType = "Security",
+
+        [Parameter()]
+        [bool] $StrictMode
+    )
+
+    # Setup the parameters for 'Get-AzADGroup' based on whether we've been given a group Name or ObjectId
+    $groupLookupSplat = $PSCmdlet.ParameterSetName -eq "ByName" ? @{DisplayName = $Name} : @{ObjectId = $ObjectId}
+    [array]$group = Get-AzADGroup @groupLookupSplat | `
+        Where-Object { $_.SecurityEnabled -eq ($GroupType -eq "Security") }
+
+    if (!$group) {
+        throw "The specified group could not be found: $($groupLookupSplat.Keys[0])=$($groupLookupSplat.Values[0])"
+    }
+    elseif ($group.Count -gt 1) {
+        throw "Found multiple matching groups: $($group | % { "ObjectId=$($_.Id);"} )"
+    }
+
+    Write-Information "Processing group membership for '$($group.DisplayName)' [ObjectId=$($group.Id)]"
+
+    $existingMemberObjectIds = $group | Get-AzADGroupMember | Select-Object -ExpandProperty Id
+
+    # Required members can be specified in various forms:
+    #   - ObjectId (groups, users & service principals)
+    #   - DisplayName (groups, users & service principals)
+    #   - UserPrincipalName (users only)
+    #   - ApplicationId (service principals only)
+    #
+    # We need the ObjectId to add them to the group - this block handles
+    # resolving the above forms into an ObjectId
+    $requiredMemberObjectIds = @()
+    foreach ($member in $RequiredMembers) {   
+        # At this stage we don't know whether the required member is a user, group or service principal.
+        # This helper will handle that lookup.
+        $resolvedMember = Get-AzureAdDirectoryObject -Criterion $member -Single
+        if ($resolvedMember) {
+            $requiredMemberObjectIds += $resolvedMember.Id
+        }
+        else {
+            Write-Warning "Skipping '$member' - not found in the directory"
+        }
+    }
+  
+    # Add any missing required members
+    $membersToAdd = $requiredMemberObjectIds | Where-Object { $_ -notin $existingMemberObjectIds }
+    if ($membersToAdd) {
+        Write-Information "Adding members: $($membersToAdd -join ', ')"
+        $group = $group | Add-AzADGroupMember -MemberObjectId $membersToAdd -PassThru
+    }
+    else {
+        Write-Information "No members to add"
+    }
+
+    # Remove extraneous members, only when StrictMode is enabled
+    if ($StrictMode) {
+        $membersToRemove = $existingMemberObjectIds | Where-Object { $_ -notin $requiredMemberObjectIds }
+        if ($membersToRemove) {
+            Write-Information "Removing members: $($membersToRemove -join ', ')"
+            $group = $group | Remove-AzADGroupMember -MemberObjectId $membersToRemove -PassThru
+        }
+        else {
+            Write-Information "No members to remove"
+        }
+    }
+
+}

--- a/module/functions/azure/aad/Assert-AzureAdSecurityGroup.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdSecurityGroup.Tests.ps1
@@ -135,7 +135,6 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
             It "should not update the group" {
                 Assert-MockCalled _buildCreateRequest -Times 0
                 Assert-MockCalled _getGroupOwners -Times 0
-                # Assert-MockCalled _buildUpdateRequest -Times 1
                 Assert-MockCalled Write-Warning -Times 0
                 Assert-MockCalled Invoke-AzRestMethod -Times 0
             }

--- a/module/functions/azure/aad/Assert-AzureAdSecurityGroup.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdSecurityGroup.Tests.ps1
@@ -6,8 +6,8 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".p
 # define other functions that will be mocked
 function _EnsureAzureConnection {}
 function Get-AzureAdDirectoryObject { param($Criterion) }
-function Get-AzADGroup {}
-function Invoke-AzRestMethod { param($Uri,$Payload) }
+function Get-AzADGroup { param($DisplayName,$ObjectId)}
+function Invoke-AzRestMethod { param($Uri,$Payload,$Method) }
 
 Describe "Assert-AzureAdSecurityGroup Tests" {
 
@@ -16,58 +16,116 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
 
     Context "Group does not exist" {
 
-        Mock Get-AzADGroup {}
-        Mock _buildUpdateRequest { @{Uri = 'https://fake'} }
+        $baseMockGroup = @{
+            DisplayName = 'testgroup'
+            MailNickname = 'testgroup@nowhere.org'
+            Description = 'just a test group'
+        }
+        $mockCreatedGroup = $baseMockGroup.Clone() + @{
+            id = (New-Guid).Guid
+            mailEnabled = $false
+            securityEnabled = $true
+        }
+
+        Mock Get-AzADGroup {} -ParameterFilter { $DisplayName }
+        Mock Get-AzADGroup { $mockCreatedGroup } -ParameterFilter { $ObjectId }
+        Mock _buildUpdateRequest {}
         Mock _getGroupOwners {}
-        Mock Invoke-AzRestMethod {}
+        Mock Invoke-AzRestMethod { @{Content = ($mockCreatedGroup | ConvertTo-Json)} } -ParameterFilter { $Method -eq "POST" -and $Uri.EndsWith("/groups") }
 
         Context "No default owners specified" {
-            $testGroup = @{
-                Name = 'testgroup'
-                EmailName = 'testgroup@nowhere.org'
-                Description = 'just a test group'
+            $testGroup = $baseMockGroup.Clone() + @{                
                 OwnersToAssignOnCreation = @()
                 StrictMode = $false
             }
             Mock Get-AzureAdDirectoryObject {}
 
-            Assert-AzureAdSecurityGroup @testGroup
+            $res = Assert-AzureAdSecurityGroup @testGroup
 
+            It "should return the new group" {
+                $res.DisplayName | Should -Be $testGroup.DisplayName
+                $res.securityEnabled | Should -Be $true
+                Assert-MockCalled Get-AzADGroup -ParameterFilter { $ObjectId -eq $mockCreatedGroup.id } -Times 1
+            }
             It "should create the group" {
                 Assert-MockCalled _buildUpdateRequest -Times 0
                 Assert-MockCalled Get-AzureAdDirectoryObject -Times 0
                 Assert-MockCalled _getGroupOwners -Times 0
-                Assert-MockCalled Invoke-AzRestMethod -Times 1 -ParameterFilter { $Uri -eq "https://graph.microsoft.com/v1.0/groups" -and $Payload -notmatch "owners" }
+                Assert-MockCalled Invoke-AzRestMethod -Times 1 `
+                    -ParameterFilter {
+                        $Method -eq "POST" -and `
+                        $Uri -eq "https://graph.microsoft.com/v1.0/groups" -and `
+                        $Payload -notmatch "owners"
+                    }
             }
         }
 
         Context "Default owner specified" {
-            $testGroup = @{
-                Name = 'testgroup'
-                EmailName = 'testgroup@nowhere.org'
-                Description = 'just a test group'
+            $testGroup = $baseMockGroup.Clone() + @{
                 OwnersToAssignOnCreation = @("someone@nowhere.org")
                 StrictMode = $false
             }
-            $mockOwnerObjectId = [guid]::NewGuid().ToString()
+            $mockOwnerObjectId = @{ id = [guid]::NewGuid().ToString() }
             Mock Get-AzureAdDirectoryObject { $mockOwnerObjectId }
 
-            Assert-AzureAdSecurityGroup @testGroup
+            $res = Assert-AzureAdSecurityGroup @testGroup
 
+            It "should return the new group" {
+                $res.DisplayName | Should -Be $testGroup.DisplayName
+                $res.securityEnabled | Should -Be $true
+                Assert-MockCalled Get-AzADGroup -ParameterFilter { $ObjectId -eq $mockCreatedGroup.id } -Times 1
+            }
             It "should create the group with the specified owner" {
                 Assert-MockCalled _buildUpdateRequest -Times 0
                 Assert-MockCalled Get-AzureAdDirectoryObject -Times 1
                 Assert-MockCalled _getGroupOwners -Times 0
-                Assert-MockCalled Invoke-AzRestMethod -Times 1 -ParameterFilter { $Uri -eq "https://graph.microsoft.com/v1.0/groups" -and $Payload -match $mockOwnerObjectId }
+                Assert-MockCalled Invoke-AzRestMethod -Times 1 `
+                    -ParameterFilter { 
+                        $Method -eq "POST" -and `
+                        $Uri -eq "https://graph.microsoft.com/v1.0/groups" -and `
+                        $Payload -match $mockOwnerObjectId.id
+                    }
             }
         }
 
         Context "Multiple default owners specified" {
-            $testGroup = @{
-                Name = 'testgroup'
-                EmailName = 'testgroup@nowhere.org'
-                Description = 'just a test group'
+            $testGroup = $baseMockGroup.Clone() + @{
                 OwnersToAssignOnCreation = @("someone@nowhere.org","MyServicePrincipal")
+                StrictMode = $false
+            }
+            $mockOwnerObjectIds = @(
+                @{ id = [guid]::NewGuid().ToString() }
+                @{ id = [guid]::NewGuid().ToString() }
+            )
+            
+            Mock Get-AzureAdDirectoryObject { $mockOwnerObjectIds[0] } -ParameterFilter { $Criterion -eq "someone@nowhere.org" }
+            Mock Get-AzureAdDirectoryObject { $mockOwnerObjectIds[1] } -ParameterFilter { $Criterion -eq "MyServicePrincipal" }
+
+            $res = Assert-AzureAdSecurityGroup @testGroup
+
+            It "should return the new group" {
+                $res.DisplayName | Should -Be $testGroup.DisplayName
+                $res.securityEnabled | Should -Be $true
+                Assert-MockCalled Get-AzADGroup -ParameterFilter { $ObjectId -eq $mockCreatedGroup.id } -Times 1
+            }
+            It "should create the group specifying all the required owners" {
+                Assert-MockCalled _buildUpdateRequest -Times 0
+                Assert-MockCalled Get-AzureAdDirectoryObject -Times 2
+                Assert-MockCalled _getGroupOwners -Times 0
+                Assert-MockCalled Invoke-AzRestMethod -Times 1 `
+                    -ParameterFilter {
+                        $Method -eq "POST" -and `
+                        $Uri -eq "https://graph.microsoft.com/v1.0/groups" -and `
+                        $Payload -match $mockOwnerObjectIds[0].id -and `
+                        $Payload -match $mockOwnerObjectIds[1].id
+                    }
+            }
+        }
+
+        # Added to catch a previous bug
+        Context "Invaild owners specified - multiple empty string owners" {
+            $testGroup = $baseMockGroup.Clone() + @{
+                OwnersToAssignOnCreation = @("","")
                 StrictMode = $false
             }
             $mockOwnerObjectIds = @( [guid]::NewGuid().ToString(), [guid]::NewGuid().ToString() )
@@ -75,51 +133,62 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
             Mock Get-AzureAdDirectoryObject { $mockOwnerObjectIds[0] } -ParameterFilter { $Criterion -eq "someone@nowhere.org" }
             Mock Get-AzureAdDirectoryObject { $mockOwnerObjectIds[1] } -ParameterFilter { $Criterion -eq "MyServicePrincipal" }
 
-            Assert-AzureAdSecurityGroup @testGroup
+            $res = Assert-AzureAdSecurityGroup @testGroup
 
-            It "should create the group specifying all the required owners" {
+            It "should return the new group" {
+                $res.DisplayName | Should -Be $testGroup.DisplayName
+                $res.securityEnabled | Should -Be $true
+                Assert-MockCalled Get-AzADGroup -ParameterFilter { $ObjectId -eq $mockCreatedGroup.id } -Times 1
+            }
+            It "should create the group with no owners" {
                 Assert-MockCalled _buildUpdateRequest -Times 0
-                Assert-MockCalled Get-AzureAdDirectoryObject -Times 2
+                Assert-MockCalled Get-AzureAdDirectoryObject -Times 0
                 Assert-MockCalled _getGroupOwners -Times 0
                 Assert-MockCalled Invoke-AzRestMethod -Times 1 `
                     -ParameterFilter { `
+                        $Method -eq "POST" -and `
                         $Uri -eq "https://graph.microsoft.com/v1.0/groups" -and `
-                        $Payload -match $mockOwnerObjectIds[0] -and `
-                        $Payload -match $mockOwnerObjectIds[1]
+                        $Payload -notmatch 'owners@odata.bind'
                     }
             }
         }
     }
-
     Context "Group already exists" {
 
         $groupObjectId = '00000000-0000-0000-0000-000000000000'
-        Mock Get-AzADGroup { return @{
-                displayName = 'testgroup'
-                id = $groupObjectId
-                mailNickname = 'testgroup'
-                mailEnabled = $false
-                securityEnabled = $true
-                description = 'just a test group'
-            }
+        $baseMockGroup = @{
+            DisplayName = 'testgroup'
+            MailNickname = 'testgroup@nowhere.org'
+            Description = 'just a test group'
         }
+        $mockExistingGroup = $baseMockGroup.Clone() + @{
+            id = $groupObjectId
+            mailEnabled = $false
+            securityEnabled = $true
+        }
+        $mockOwnerObjectId = [guid]::NewGuid().ToString()
+
+        Mock Get-AzADGroup { $mockExistingGroup } -ParameterFilter { $DisplayName }
         Mock _buildCreateRequest {}
         Mock _getGroupOwners { @('11111111-1111-1111-1111-111111111111') }
-        Mock Invoke-AzRestMethod {}
-        $mockOwnerObjectId = [guid]::NewGuid().ToString()
+        Mock Invoke-AzRestMethod {} -ParameterFilter { $Method -eq "PATCH" -and $Uri.EndsWith("/$groupObjectId") }
         Mock Get-AzureAdDirectoryObject { $mockOwnerObjectId }
         Mock Write-Warning {}
 
         Context "No default owners - No changes required" {
-            $testGroup = @{
-                Name = 'testgroup'
-                EmailName = 'testgroup@nowhere.org'
-                Description = 'just a test group'
+            $testGroup = $baseMockGroup.Clone() + @{
                 OwnersToAssignOnCreation = @()
                 StrictMode = $false
             }
-            Assert-AzureAdSecurityGroup @testGroup
+            Mock Get-AzADGroup { $mockExistingGroup } -ParameterFilter { $ObjectId }
 
+            $res = Assert-AzureAdSecurityGroup @testGroup
+
+            It "should return the new group" {
+                $res.DisplayName | Should -Be $testGroup.DisplayName
+                $res.Description | Should -Be $testGroup.Description
+                Assert-MockCalled Get-AzADGroup -ParameterFilter { $ObjectId } -Times 0
+            }
             It "should not update the group" {
                 Assert-MockCalled _buildCreateRequest -Times 0
                 Assert-MockCalled _getGroupOwners -Times 0
@@ -130,15 +199,19 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
 
         $updatedGroupDesc = 'just a test group with a different description'
         Context "Description updated (StrictMode=false)" {
-            $testGroup = @{
-                Name = 'testgroup'
-                EmailName = 'testgroup@nowhere.org'
-                Description = $updatedGroupDesc
+            $testGroup = $baseMockGroup.Clone() + @{
                 OwnersToAssignOnCreation = @()
                 StrictMode = $false
             }
-            Assert-AzureAdSecurityGroup @testGroup
+            Mock Get-AzADGroup { $mockExistingGroup } -ParameterFilter { $ObjectId }
 
+            $res = Assert-AzureAdSecurityGroup @testGroup
+
+            It "should return the existing group" {
+                $res.DisplayName | Should -Be $testGroup.DisplayName
+                $res.Description | Should -Be $mockExistingGroup.Description
+                Assert-MockCalled Get-AzADGroup -ParameterFilter { $ObjectId } -Times 0
+            }
             It "should not update the group" {
                 Assert-MockCalled _buildCreateRequest -Times 0
                 Assert-MockCalled _getGroupOwners -Times 0
@@ -148,37 +221,50 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
         }
 
         Context "Description updated (StrictMode=true)" {
-            $testGroup = @{
-                Name = 'testgroup'
-                EmailName = 'testgroup@nowhere.org'
+
+            $mockUpdatedGroup = $mockExistingGroup.Clone()
+            $mockUpdatedGroup.Description = $updatedGroupDesc
+            Mock Get-AzADGroup { $mockUpdatedGroup } -ParameterFilter { $ObjectId }
+
+            $testGroup = $baseMockGroup.Clone()
+            $testGroup.Remove("Description")
+            $testGroup += @{
                 Description = $updatedGroupDesc
                 OwnersToAssignOnCreation = @()
                 StrictMode = $true
             }
-            Assert-AzureAdSecurityGroup @testGroup
+            $res = Assert-AzureAdSecurityGroup @testGroup
 
+            It "should return the updated group" {
+                $res.DisplayName | Should -Be $testGroup.DisplayName
+                $res.Description | Should -Be $updatedGroupDesc
+                Assert-MockCalled Get-AzADGroup -ParameterFilter { $ObjectId -eq $groupObjectId } -Times 1
+            }
             It "should update the group" {
                 Assert-MockCalled _buildCreateRequest -Times 0
                 Assert-MockCalled _getGroupOwners -Times 0
                 Assert-MockCalled Get-AzureAdDirectoryObject -Times 0
                 Assert-MockCalled Invoke-AzRestMethod -Times 1 `
-                    -ParameterFilter {  
-                        $Uri -eq "https://graph.microsoft.com/v1.0/groups/$groupObjectId" -and  
+                    -ParameterFilter {
+                        $Method -eq "PATCH" -and `
+                        $Uri -eq "https://graph.microsoft.com/v1.0/groups/$groupObjectId" -and `
                         $Payload -notmatch "owners" -and $Payload -match $updatedGroupDesc
                     }
             }
         }
 
         Context "Default owners - No changes required" {
-            $testGroup = @{
-                Name = 'testgroup'
-                EmailName = 'testgroup@nowhere.org'
-                Description = 'just a test group'
+            $testGroup = $baseMockGroup.Clone() + @{
                 OwnersToAssignOnCreation = @('anothergroup@nowhere.com')
                 StrictMode = $false
             }
-            Assert-AzureAdSecurityGroup @testGroup
+            $res = Assert-AzureAdSecurityGroup @testGroup
 
+            It "should return the existing group" {
+                $res.DisplayName | Should -Be $mockExistingGroup.DisplayName
+                $res.mailEnabled | Should -Be $mockExistingGroup.mailEnabled
+                Assert-MockCalled Get-AzADGroup -ParameterFilter { $ObjectId } -Times 0
+            }
             It "should not update the group" {
                 Assert-MockCalled _buildCreateRequest -Times 0
                 Assert-MockCalled _getGroupOwners -Times 0
@@ -189,15 +275,17 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
         }
 
         Context "Default owners - owner missing (StrictMode=false)" {
-            $testGroup = @{
-                Name = 'testgroup'
-                EmailName = 'testgroup@nowhere.org'
-                Description = 'just a test group'
+            $testGroup = $baseMockGroup.Clone() + @{
                 OwnersToAssignOnCreation = @('someone@nowhere.org')
                 StrictMode = $false
             }
-            Assert-AzureAdSecurityGroup @testGroup
+            $res = Assert-AzureAdSecurityGroup @testGroup
 
+            It "should return the existing group" {
+                $res.DisplayName | Should -Be $mockExistingGroup.DisplayName
+                $res.mailEnabled | Should -Be $mockExistingGroup.mailEnabled
+                Assert-MockCalled Get-AzADGroup -ParameterFilter { $ObjectId } -Times 0
+            }
             It "should not update the group" {
                 Assert-MockCalled _buildCreateRequest -Times 0
                 Assert-MockCalled _getGroupOwners -Times 0
@@ -208,15 +296,17 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
         }
 
         Context "Default owners - owner missing (StrictMode=true)" {
-            $testGroup = @{
-                Name = 'testgroup'
-                EmailName = 'testgroup@nowhere.org'
-                Description = 'just a test group'
+            $testGroup = $baseMockGroup.Clone() + @{
                 OwnersToAssignOnCreation = @('someone@nowhere.org')
                 StrictMode = $true
             }
-            Assert-AzureAdSecurityGroup @testGroup
+            $res = Assert-AzureAdSecurityGroup @testGroup
 
+            It "should return the existing group" {
+                $res.DisplayName | Should -Be $mockExistingGroup.DisplayName
+                $res.mailEnabled | Should -Be $mockExistingGroup.mailEnabled
+                Assert-MockCalled Get-AzADGroup -ParameterFilter { $ObjectId } -Times 0
+            }
             It "should not update the group and warn the owners cannot be updated" {
                 Assert-MockCalled _buildCreateRequest -Times 0
                 Assert-MockCalled _getGroupOwners -Times 1
@@ -227,15 +317,17 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
         }
 
         Context "Backwards-compatible handling of StrictMode" {
-            $testGroup = @{
-                Name = 'testgroup'
-                EmailName = 'testgroup@nowhere.org'
-                Description = 'just a test group'
+            $testGroup = $baseMockGroup.Clone() + @{
                 OwnersToAssignOnCreation = @('MyServicePrincipal')
                 # Omit the StrictMode parameter to simulate a consumer of an earlier version, before it was added
             }
-            Assert-AzureAdSecurityGroup @testGroup
+            $res = Assert-AzureAdSecurityGroup @testGroup
 
+            It "should return the existing group" {
+                $res.DisplayName | Should -Be $mockExistingGroup.DisplayName
+                $res.mailEnabled | Should -Be $mockExistingGroup.mailEnabled
+                Assert-MockCalled Get-AzADGroup -ParameterFilter { $ObjectId } -Times 0
+            }
             It "should not update the group and warn the owners cannot be updated" {
                 Assert-MockCalled _buildCreateRequest -Times 0
                 Assert-MockCalled _getGroupOwners -Times 1

--- a/module/functions/azure/aad/Assert-AzureAdSecurityGroup.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdSecurityGroup.Tests.ps1
@@ -1,0 +1,192 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".ps1")
+
+. "$here\$sut"
+
+Describe "Assert-AzureAdSecurityGroup Tests" {
+
+    Mock Write-Host {}
+
+    Context "Group does not exist" {
+
+        Mock Get-AzADGroup {}
+        Mock _buildUpdateRequest { @{Uri = 'https://fake'} }
+        Mock _getGroupOwners {}
+        Mock Invoke-AzRestMethod {}
+
+        Context "No default owners" {
+            $testGroup = @{
+                Name = 'testgroup'
+                EmailName = 'testgroup@nowhere.org'
+                Description = 'just a test group'
+                OwnersToAssignOnCreation = @()
+                StrictMode = $false
+            }
+            Assert-AzureAdSecurityGroup @testGroup
+
+            It "should create the group" {
+                Assert-MockCalled _buildUpdateRequest -Times 0
+                Assert-MockCalled _getGroupOwners -Times 0
+                Assert-MockCalled Invoke-AzRestMethod -Times 1
+            }
+        }
+
+        Context "Default owners" {
+            $testGroup = @{
+                Name = 'testgroup'
+                EmailName = 'testgroup@nowhere.org'
+                Description = 'just a test group'
+                OwnersToAssignOnCreation = @("someone@nowhere.org")
+                StrictMode = $false
+            }
+            Assert-AzureAdSecurityGroup @testGroup
+
+            It "should create the group" {
+                Assert-MockCalled _buildUpdateRequest -Times 0
+                Assert-MockCalled _getGroupOwners -Times 0
+                Assert-MockCalled Invoke-AzRestMethod -Times 1
+            }
+        }
+    }
+
+    Context "Group already exists" {
+
+        Mock Get-AzADGroup { return @{
+                displayName = 'testgroup'
+                id = '00000000-0000-0000-0000-000000000000'
+                mailNickname = 'testgroup'
+                mailEnabled = $false
+                securityEnabled = $true
+                description = 'just a test group'
+            }
+        }
+        Mock _buildCreateRequest {}
+        Mock _getGroupOwners { @('11111111-1111-1111-1111-111111111111') }
+        Mock Invoke-AzRestMethod {}
+        Mock Write-Warning {}
+
+        Context "No default owners - No changes required" {
+            $testGroup = @{
+                Name = 'testgroup'
+                EmailName = 'testgroup@nowhere.org'
+                Description = 'just a test group'
+                OwnersToAssignOnCreation = @()
+                StrictMode = $false
+            }
+            Assert-AzureAdSecurityGroup @testGroup
+
+            It "should not update the group" {
+                Assert-MockCalled _buildCreateRequest -Times 0
+                Assert-MockCalled _getGroupOwners -Times 0
+                Assert-MockCalled Invoke-AzRestMethod -Times 0
+            }
+        }
+
+        Context "Description updated (StrictMode=false)" {
+            $testGroup = @{
+                Name = 'testgroup'
+                EmailName = 'testgroup@nowhere.org'
+                Description = 'just a test group with a different description'
+                OwnersToAssignOnCreation = @()
+                StrictMode = $false
+            }
+            Assert-AzureAdSecurityGroup @testGroup
+
+            It "should not update the group" {
+                Assert-MockCalled _buildCreateRequest -Times 0
+                Assert-MockCalled _getGroupOwners -Times 0
+                Assert-MockCalled Invoke-AzRestMethod -Times 0
+            }
+        }
+
+        Context "Description updated (StrictMode=true)" {
+            $testGroup = @{
+                Name = 'testgroup'
+                EmailName = 'testgroup@nowhere.org'
+                Description = 'just a test group with a different description'
+                OwnersToAssignOnCreation = @()
+                StrictMode = $true
+            }
+            Assert-AzureAdSecurityGroup @testGroup
+
+            It "should update the group" {
+                Assert-MockCalled _buildCreateRequest -Times 0
+                Assert-MockCalled _getGroupOwners -Times 0
+                Assert-MockCalled Invoke-AzRestMethod -Times 1
+            }
+        }
+
+        Context "Default owners - No changes required" {
+            $testGroup = @{
+                Name = 'testgroup'
+                EmailName = 'testgroup@nowhere.org'
+                Description = 'just a test group'
+                OwnersToAssignOnCreation = @('11111111-1111-1111-1111-111111111111')
+                StrictMode = $false
+            }
+            Assert-AzureAdSecurityGroup @testGroup
+
+            It "should not update the group" {
+                Assert-MockCalled _buildCreateRequest -Times 0
+                Assert-MockCalled _getGroupOwners -Times 0
+                # Assert-MockCalled _buildUpdateRequest -Times 1
+                Assert-MockCalled Write-Warning -Times 0
+                Assert-MockCalled Invoke-AzRestMethod -Times 0
+            }
+        }
+
+        Context "Default owners - owner missing (StrictMode=false)" {
+            $testGroup = @{
+                Name = 'testgroup'
+                EmailName = 'testgroup@nowhere.org'
+                Description = 'just a test group'
+                OwnersToAssignOnCreation = @('22222222-2222-2222-2222-222222222222')
+                StrictMode = $false
+            }
+            Assert-AzureAdSecurityGroup @testGroup
+
+            It "should not update the group" {
+                Assert-MockCalled _buildCreateRequest -Times 0
+                Assert-MockCalled _getGroupOwners -Times 0
+                Assert-MockCalled Write-Warning -Times 0
+                Assert-MockCalled Invoke-AzRestMethod -Times 0
+            }
+        }
+
+        Context "Default owners - owner missing (StrictMode=true)" {
+            $testGroup = @{
+                Name = 'testgroup'
+                EmailName = 'testgroup@nowhere.org'
+                Description = 'just a test group'
+                OwnersToAssignOnCreation = @('22222222-2222-2222-2222-222222222222')
+                StrictMode = $true
+            }
+            Assert-AzureAdSecurityGroup @testGroup
+
+            It "should not update the group and warn the owners cannot be updated" {
+                Assert-MockCalled _buildCreateRequest -Times 0
+                Assert-MockCalled _getGroupOwners -Times 1
+                Assert-MockCalled Write-Warning -Times 1
+                Assert-MockCalled Invoke-AzRestMethod -Times 0
+            }
+        }
+
+        Context "Backwards-compatible handling of StrictMode" {
+            $testGroup = @{
+                Name = 'testgroup'
+                EmailName = 'testgroup@nowhere.org'
+                Description = 'just a test group'
+                OwnersToAssignOnCreation = @('22222222-2222-2222-2222-222222222222')
+                # Omit the StrictMode parameter to simulate a consumer of an earlier version, before it was added
+            }
+            Assert-AzureAdSecurityGroup @testGroup
+
+            It "should not update the group and warn the owners cannot be updated" {
+                Assert-MockCalled _buildCreateRequest -Times 0
+                Assert-MockCalled _getGroupOwners -Times 1
+                Assert-MockCalled Write-Warning -Times 1
+                Assert-MockCalled Invoke-AzRestMethod -Times 0
+            }
+        }
+    }
+}

--- a/module/functions/azure/aad/Assert-AzureAdSecurityGroup.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdSecurityGroup.Tests.ps1
@@ -6,6 +6,7 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".p
 # define other functions that will be mocked
 function _EnsureAzureConnection {}
 function Get-AzADGroup {}
+function Invoke-AzRestMethod {}
 
 Describe "Assert-AzureAdSecurityGroup Tests" {
 

--- a/module/functions/azure/aad/Assert-AzureAdSecurityGroup.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdSecurityGroup.Tests.ps1
@@ -5,6 +5,7 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".p
 
 # define other functions that will be mocked
 function _EnsureAzureConnection {}
+function Get-AzADGroup {}
 
 Describe "Assert-AzureAdSecurityGroup Tests" {
 

--- a/module/functions/azure/aad/Assert-AzureAdSecurityGroup.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdSecurityGroup.Tests.ps1
@@ -3,8 +3,12 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".p
 
 . "$here\$sut"
 
+# define other functions that will be mocked
+function _EnsureAzureConnection {}
+
 Describe "Assert-AzureAdSecurityGroup Tests" {
 
+    Mock _EnsureAzureConnection { $true }
     Mock Write-Host {}
 
     Context "Group does not exist" {

--- a/module/functions/azure/aad/Assert-AzureAdSecurityGroup.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdSecurityGroup.Tests.ps1
@@ -5,8 +5,9 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".p
 
 # define other functions that will be mocked
 function _EnsureAzureConnection {}
+function Get-AzureAdDirectoryObject { param($Criterion) }
 function Get-AzADGroup {}
-function Invoke-AzRestMethod {}
+function Invoke-AzRestMethod { param($Uri,$Payload) }
 
 Describe "Assert-AzureAdSecurityGroup Tests" {
 
@@ -20,7 +21,7 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
         Mock _getGroupOwners {}
         Mock Invoke-AzRestMethod {}
 
-        Context "No default owners" {
+        Context "No default owners specified" {
             $testGroup = @{
                 Name = 'testgroup'
                 EmailName = 'testgroup@nowhere.org'
@@ -28,16 +29,19 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
                 OwnersToAssignOnCreation = @()
                 StrictMode = $false
             }
+            Mock Get-AzureAdDirectoryObject {}
+
             Assert-AzureAdSecurityGroup @testGroup
 
             It "should create the group" {
                 Assert-MockCalled _buildUpdateRequest -Times 0
+                Assert-MockCalled Get-AzureAdDirectoryObject -Times 0
                 Assert-MockCalled _getGroupOwners -Times 0
-                Assert-MockCalled Invoke-AzRestMethod -Times 1
+                Assert-MockCalled Invoke-AzRestMethod -Times 1 -ParameterFilter { $Uri -eq "https://graph.microsoft.com/v1.0/groups" -and $Payload -notmatch "owners" }
             }
         }
 
-        Context "Default owners" {
+        Context "Default owner specified" {
             $testGroup = @{
                 Name = 'testgroup'
                 EmailName = 'testgroup@nowhere.org'
@@ -45,21 +49,54 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
                 OwnersToAssignOnCreation = @("someone@nowhere.org")
                 StrictMode = $false
             }
+            $mockOwnerObjectId = [guid]::NewGuid().ToString()
+            Mock Get-AzureAdDirectoryObject { $mockOwnerObjectId }
+
             Assert-AzureAdSecurityGroup @testGroup
 
-            It "should create the group" {
+            It "should create the group with the specified owner" {
                 Assert-MockCalled _buildUpdateRequest -Times 0
+                Assert-MockCalled Get-AzureAdDirectoryObject -Times 1
                 Assert-MockCalled _getGroupOwners -Times 0
-                Assert-MockCalled Invoke-AzRestMethod -Times 1
+                Assert-MockCalled Invoke-AzRestMethod -Times 1 -ParameterFilter { $Uri -eq "https://graph.microsoft.com/v1.0/groups" -and $Payload -match $mockOwnerObjectId }
+            }
+        }
+
+        Context "Multiple default owners specified" {
+            $testGroup = @{
+                Name = 'testgroup'
+                EmailName = 'testgroup@nowhere.org'
+                Description = 'just a test group'
+                OwnersToAssignOnCreation = @("someone@nowhere.org","MyServicePrincipal")
+                StrictMode = $false
+            }
+            $mockOwnerObjectIds = @( [guid]::NewGuid().ToString(), [guid]::NewGuid().ToString() )
+            
+            Mock Get-AzureAdDirectoryObject { $mockOwnerObjectIds[0] } -ParameterFilter { $Criterion -eq "someone@nowhere.org" }
+            Mock Get-AzureAdDirectoryObject { $mockOwnerObjectIds[1] } -ParameterFilter { $Criterion -eq "MyServicePrincipal" }
+
+            Assert-AzureAdSecurityGroup @testGroup
+
+            It "should create the group specifying all the required owners" {
+                Assert-MockCalled _buildUpdateRequest -Times 0
+                Assert-MockCalled Get-AzureAdDirectoryObject -Times 2
+                Assert-MockCalled _getGroupOwners -Times 0
+                Assert-MockCalled Invoke-AzRestMethod -Times 1 `
+                    -ParameterFilter { `
+                        $Uri -eq "https://graph.microsoft.com/v1.0/groups" -and `
+                        $Payload -match $mockOwnerObjectIds[0] -and `
+                        $Payload -match $mockOwnerObjectIds[1]
+                    }
             }
         }
     }
 
     Context "Group already exists" {
 
+        $groupObjectId = '00000000-0000-0000-0000-000000000000'
         Mock Get-AzADGroup { return @{
                 displayName = 'testgroup'
-                id = '00000000-0000-0000-0000-000000000000'
+                id = $groupObjectId
                 mailNickname = 'testgroup'
                 mailEnabled = $false
                 securityEnabled = $true
@@ -69,6 +106,8 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
         Mock _buildCreateRequest {}
         Mock _getGroupOwners { @('11111111-1111-1111-1111-111111111111') }
         Mock Invoke-AzRestMethod {}
+        $mockOwnerObjectId = [guid]::NewGuid().ToString()
+        Mock Get-AzureAdDirectoryObject { $mockOwnerObjectId }
         Mock Write-Warning {}
 
         Context "No default owners - No changes required" {
@@ -84,15 +123,17 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
             It "should not update the group" {
                 Assert-MockCalled _buildCreateRequest -Times 0
                 Assert-MockCalled _getGroupOwners -Times 0
+                Assert-MockCalled Get-AzureAdDirectoryObject -Times 0
                 Assert-MockCalled Invoke-AzRestMethod -Times 0
             }
         }
 
+        $updatedGroupDesc = 'just a test group with a different description'
         Context "Description updated (StrictMode=false)" {
             $testGroup = @{
                 Name = 'testgroup'
                 EmailName = 'testgroup@nowhere.org'
-                Description = 'just a test group with a different description'
+                Description = $updatedGroupDesc
                 OwnersToAssignOnCreation = @()
                 StrictMode = $false
             }
@@ -101,6 +142,7 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
             It "should not update the group" {
                 Assert-MockCalled _buildCreateRequest -Times 0
                 Assert-MockCalled _getGroupOwners -Times 0
+                Assert-MockCalled Get-AzureAdDirectoryObject -Times 0
                 Assert-MockCalled Invoke-AzRestMethod -Times 0
             }
         }
@@ -109,7 +151,7 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
             $testGroup = @{
                 Name = 'testgroup'
                 EmailName = 'testgroup@nowhere.org'
-                Description = 'just a test group with a different description'
+                Description = $updatedGroupDesc
                 OwnersToAssignOnCreation = @()
                 StrictMode = $true
             }
@@ -118,7 +160,12 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
             It "should update the group" {
                 Assert-MockCalled _buildCreateRequest -Times 0
                 Assert-MockCalled _getGroupOwners -Times 0
-                Assert-MockCalled Invoke-AzRestMethod -Times 1
+                Assert-MockCalled Get-AzureAdDirectoryObject -Times 0
+                Assert-MockCalled Invoke-AzRestMethod -Times 1 `
+                    -ParameterFilter {  
+                        $Uri -eq "https://graph.microsoft.com/v1.0/groups/$groupObjectId" -and  
+                        $Payload -notmatch "owners" -and $Payload -match $updatedGroupDesc
+                    }
             }
         }
 
@@ -127,7 +174,7 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
                 Name = 'testgroup'
                 EmailName = 'testgroup@nowhere.org'
                 Description = 'just a test group'
-                OwnersToAssignOnCreation = @('11111111-1111-1111-1111-111111111111')
+                OwnersToAssignOnCreation = @('anothergroup@nowhere.com')
                 StrictMode = $false
             }
             Assert-AzureAdSecurityGroup @testGroup
@@ -135,6 +182,7 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
             It "should not update the group" {
                 Assert-MockCalled _buildCreateRequest -Times 0
                 Assert-MockCalled _getGroupOwners -Times 0
+                Assert-MockCalled Get-AzureAdDirectoryObject -Times 1
                 Assert-MockCalled Write-Warning -Times 0
                 Assert-MockCalled Invoke-AzRestMethod -Times 0
             }
@@ -145,7 +193,7 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
                 Name = 'testgroup'
                 EmailName = 'testgroup@nowhere.org'
                 Description = 'just a test group'
-                OwnersToAssignOnCreation = @('22222222-2222-2222-2222-222222222222')
+                OwnersToAssignOnCreation = @('someone@nowhere.org')
                 StrictMode = $false
             }
             Assert-AzureAdSecurityGroup @testGroup
@@ -153,6 +201,7 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
             It "should not update the group" {
                 Assert-MockCalled _buildCreateRequest -Times 0
                 Assert-MockCalled _getGroupOwners -Times 0
+                Assert-MockCalled Get-AzureAdDirectoryObject -Times 1
                 Assert-MockCalled Write-Warning -Times 0
                 Assert-MockCalled Invoke-AzRestMethod -Times 0
             }
@@ -163,7 +212,7 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
                 Name = 'testgroup'
                 EmailName = 'testgroup@nowhere.org'
                 Description = 'just a test group'
-                OwnersToAssignOnCreation = @('22222222-2222-2222-2222-222222222222')
+                OwnersToAssignOnCreation = @('someone@nowhere.org')
                 StrictMode = $true
             }
             Assert-AzureAdSecurityGroup @testGroup
@@ -171,6 +220,7 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
             It "should not update the group and warn the owners cannot be updated" {
                 Assert-MockCalled _buildCreateRequest -Times 0
                 Assert-MockCalled _getGroupOwners -Times 1
+                Assert-MockCalled Get-AzureAdDirectoryObject -Times 1
                 Assert-MockCalled Write-Warning -Times 1
                 Assert-MockCalled Invoke-AzRestMethod -Times 0
             }
@@ -181,7 +231,7 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
                 Name = 'testgroup'
                 EmailName = 'testgroup@nowhere.org'
                 Description = 'just a test group'
-                OwnersToAssignOnCreation = @('22222222-2222-2222-2222-222222222222')
+                OwnersToAssignOnCreation = @('MyServicePrincipal')
                 # Omit the StrictMode parameter to simulate a consumer of an earlier version, before it was added
             }
             Assert-AzureAdSecurityGroup @testGroup
@@ -189,6 +239,7 @@ Describe "Assert-AzureAdSecurityGroup Tests" {
             It "should not update the group and warn the owners cannot be updated" {
                 Assert-MockCalled _buildCreateRequest -Times 0
                 Assert-MockCalled _getGroupOwners -Times 1
+                Assert-MockCalled Get-AzureAdDirectoryObject -Times 1
                 Assert-MockCalled Write-Warning -Times 1
                 Assert-MockCalled Invoke-AzRestMethod -Times 0
             }

--- a/module/functions/azure/aad/Assert-AzureAdSecurityGroup.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdSecurityGroup.ps1
@@ -53,7 +53,8 @@ function Assert-AzureAdSecurityGroup
         [bool] $StrictMode = $true      # default to true, to ensure backwards-compatible behaviour
     )
 
-    _EnsureAzureConnection -AzPowerShell | Out-Null
+    # Check whether we have a valid AzPowerShell connection, but no subscription-level access is required
+    _EnsureAzureConnection -AzPowerShell -TenantOnly -ErrorAction Stop | Out-Null
     
     $existingGroup = Get-AzADGroup -DisplayName $name
 

--- a/module/functions/azure/aad/Assert-AzureAdSecurityGroup.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdSecurityGroup.ps1
@@ -1,4 +1,4 @@
-# <copyright file="Assert-AzureAdGroup.ps1" company="Endjin Limited">
+# <copyright file="Assert-AzureAdSecurityGroup.ps1" company="Endjin Limited">
 # Copyright (c) Endjin Limited. All rights reserved.
 # </copyright>
 
@@ -7,7 +7,7 @@
 Creates or updates a AzureAD group.
 
 .DESCRIPTION
-Uses the azure-cli to configure an AzureAD group.
+Uses Azure PowerShell to create an AzureAD security group.
 
 .PARAMETER Name
 The display name of the group.

--- a/module/functions/azure/aad/Assert-AzureAdSecurityGroup.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdSecurityGroup.ps1
@@ -60,7 +60,8 @@ function Assert-AzureAdSecurityGroup
 
     # Resolve the ObjectId for any specified owners
     $ownersToAssignObjectIds = $OwnersToAssignOnCreation |
-        ForEach-Object { Get-AzureAdDirectoryObject -Criterion $_ }
+                                    Where-Object { $_ } |
+                                    ForEach-Object { Get-AzureAdDirectoryObject -Criterion $_ }
 
     if ($existingGroup) {
         Write-Host "Security group with name $($existingGroup.displayName) already exists."
@@ -133,9 +134,11 @@ function _buildCreateRequest {
 
     if ($OwnersToAssignOnCreation) {
         $body["owners@odata.bind"] = @()
-        $body["owners@odata.bind"] += $OwnersObjectIds | ForEach-Object {
-            "https://graph.microsoft.com/v1.0/directoryObjects/$_"
-        }
+        $body["owners@odata.bind"] += ($OwnersObjectIds | 
+                Where-Object { $_ } |
+                ForEach-Object {
+                    "https://graph.microsoft.com/v1.0/directoryObjects/$_"
+                })
     }
 
     if ($Description) {

--- a/module/functions/azure/aad/Assert-AzureAdSecurityGroup.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdSecurityGroup.ps1
@@ -23,7 +23,7 @@ The description of the group
 
 .PARAMETER OwnersToAssignOnCreation
 The DisplayName, UserPrincipalName, ObjectId or ApplicationId of the users, groups, service principals to assign as owners to the group.
-Note, that if the group already exists, we will not attempt to assign the owners (see the note in the description for me details)
+Note, that if the group already exists, we will not attempt to assign the owners (see the note in the description for more details)
 
 .PARAMETER StrictMode
 When true, the group's description forms part of the idempotency check.  If the specified description does not match the group's

--- a/module/functions/azure/aad/Assert-AzureAdSecurityGroup.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdSecurityGroup.ps1
@@ -68,7 +68,7 @@ function Assert-AzureAdSecurityGroup
     if ($existingGroup) {
         Write-Host "Security group with name $($existingGroup.displayName) already exists."
 
-        if ($ownersToAssignObjectIds -and $StrictMode) {
+        if ($ownersToAssignObjectIds) {
             $existingOwners = _getGroupOwners -GroupObjectId $existingGroup.id
 
             $ownersToAssignObjectIds | ForEach-Object {

--- a/module/functions/azure/aad/Assert-AzureAdSecurityGroup.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdSecurityGroup.ps1
@@ -50,6 +50,8 @@ function Assert-AzureAdSecurityGroup
         [bool] $StrictMode = $true      # default to true, to ensure backwards-compatible behaviour
     )
 
+    _EnsureAzureConnection -AzPowerShell | Out-Null
+    
     $existingGroup = Get-AzADGroup -DisplayName $name
 
     if ($existingGroup) {

--- a/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.Tests.ps1
@@ -6,6 +6,7 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".p
 # Make external dependencies available for mocking
 function Get-AzKeyVaultSecret {}
 function Set-AzKeyVaultSecret {}
+function Get-AzContext {}
 function New-AzADAppCredential { param( [Parameter(ValueFromPipeline = $true)]$ApplicationObject, [Parameter()]$DisplayName, [Parameter()]$EndDate ) }
 function New-AzADServicePrincipalCredential { param( [Parameter(ValueFromPipeline = $true)]$ServicePrincipalObject, [Parameter()]$EndDate ) }
 function Invoke-AzRestMethod { param($Uri, $Method, $Payload) }
@@ -30,6 +31,7 @@ Describe "Assert-AzureServicePrincipalForRbac Tests" {
     Mock New-AzADAppCredential { @{ SecretText = ("mock-secret" | ConvertTo-SecureString -AsPlainText) }}
     Mock New-AzADServicePrincipalCredential { @{ SecretText = ("mock-secret" | ConvertTo-SecureString -AsPlainText) }}
     Mock Set-AzKeyVaultSecret {}
+    Mock Get-AzContext { @{ Tenant = @{Id = "00000000-0000-0000-0000-000000000009"} } }
 
     Context "Not using Key Vault" {
 

--- a/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.Tests.ps1
@@ -1,0 +1,521 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".ps1")
+
+. "$here\$sut"
+
+# Make external dependencies available for mocking
+function Get-AzKeyVaultSecret {}
+function Set-AzKeytVaultSecret {}
+function New-AzADAppCredential { param( [Parameter(ValueFromPipeline = $true)]$ApplicationObject, [Parameter()]$DisplayName, [Parameter()]$EndDate ) }
+function New-AzADServicePrincipalCredential { param( [Parameter(ValueFromPipeline = $true)]$ServicePrincipalObject, [Parameter()]$EndDate ) }
+function Invoke-AzRestMethod { param($Uri, $Method, $Payload) }
+function _EnsureAzureConnection {}
+function Write-Host {}
+
+Describe "Assert-AzureServicePrincipalForRbac Tests" {
+
+    # Setup mock objects
+    $mockSp =  @{
+        id = '00000000-0000-0000-0000-000000000001'
+        appId = [guid]::Empty
+        displayName = "mock-sp"
+    }
+    $mockApp =  @{
+        id = '00000000-0000-0000-0000-000000000002'
+        appId = [guid]::Empty
+        displayName = "mock-sp"
+    }
+
+    # Global mocks
+    Mock New-AzADAppCredential { @{ SecretText = ("mock-secret" | ConvertTo-SecureString -AsPlainText) }}
+    Mock New-AzADServicePrincipalCredential { @{ SecretText = ("mock-secret" | ConvertTo-SecureString -AsPlainText) }}
+    Mock Set-AzKeyVaultSecret {}
+
+    Context "Not using Key Vault" {
+
+        Mock Get-AzKeyVaultSecret {}
+
+        Context "Using service principal credentials" {
+
+            Describe "Creating a new service principal with default options" {
+
+                Mock Invoke-AzRestMethod { @{ Content = ($mockSp | ConvertTo-Json) } }
+                Mock _newApplication { $mockApp }
+    
+                Mock _getApplication {}
+                Mock _getServicePrincipal {}
+    
+                $res = Assert-AzureServicePrincipalForRbac `
+                            -Name "mock-sp" `
+                            -CredentialDisplayName "mock-credential"
+    
+                It "should create a new service principal" {
+                    $res.Count | Should -Be 2
+                    $res[0].id | Should -Be '00000000-0000-0000-0000-000000000001'
+                    $res[1] | Should -Be "mock-secret"
+    
+                    Assert-MockCalled _getApplication -Times 1 -ParameterFilter { $DisplayName -eq 'mock-sp' }
+                    Assert-MockCalled _newApplication -Times 1 -ParameterFilter { $DisplayName -eq 'mock-sp' }
+                    Assert-MockCalled Invoke-AzRestMethod -Times 1 -ParameterFilter { $Uri.EndsWith('servicePrincipals') -and $Method -eq 'POST' -and $Payload -imatch '"appId": "00000000-0000-0000-0000-000000000000"' }
+                }
+    
+                It "should not check for an existing secret in the key vault" {
+                    Assert-MockCalled Get-AzKeyVaultSecret -Times 0     # the SP does not exist so we shouldn't be checking for ean existing secret in key vault
+                }
+    
+                It "should create a new service principal credential" {
+                    Assert-MockCalled New-AzADServicePrincipalCredential -Times 1
+                    Assert-MockCalled New-AzADAppCredential -Times 0
+                }
+    
+                It "should not update the key vault secret" {
+                    Assert-MockCalled Set-AzKeyVaultSecret -Times 0
+                }
+            }
+    
+            Describe "Updating an existing service principal with default options" {
+    
+                Mock _getServicePrincipal { $mockSp }
+                Mock _getApplication { $mockApp }
+    
+                Mock _newApplication {}
+                Mock _handleCredential {}
+                Mock _newServicePrincipal {}
+    
+                $res = Assert-AzureServicePrincipalForRbac `
+                            -Name "mock-sp" `
+                            -CredentialDisplayName "mock-credential"
+    
+                It "should not create a new service principal" {
+                    Assert-MockCalled _newApplication -Times 0
+                    Assert-MockCalled _newServicePrincipal -Times 0
+                }
+                
+                It "should not check for an existing secret in the key vault" {
+                    Assert-MockCalled Get-AzKeyVaultSecret -Times 0     # the SP does not exist so we shouldn't be checking for ean existing secret in key vault
+                }
+    
+                It "should not update the service principal credential" {
+                    $res.Count | Should -Be 2
+                    $res[0].id | Should -Be '00000000-0000-0000-0000-000000000001'
+                    $res[1] | Should -Be $null
+    
+                    Assert-MockCalled _getApplication -Times 0
+                    Assert-MockCalled _handleCredential -Times 0
+                }
+    
+                It "should not update the key vault secret" {
+                    Assert-MockCalled Set-AzKeyVaultSecret -Times 0
+                }
+            }
+    
+            Describe "Updating an existing service principal with the 'RotateSecret' option" {
+    
+                Mock _getServicePrincipal { $mockSp }
+                Mock _getApplication { $mockApp }
+    
+                Mock _newApplication {}
+                Mock _newServicePrincipal {}
+    
+                $res = Assert-AzureServicePrincipalForRbac `
+                            -Name "mock-sp" `
+                            -CredentialDisplayName "mock-credential" `
+                            -RotateSecret
+    
+                It "should not create a new service principal" {
+                    Assert-MockCalled _newApplication -Times 0
+                    Assert-MockCalled _newServicePrincipal -Times 0
+                }
+    
+                It "should not check for an existing secret in the key vault" {
+                    Assert-MockCalled Get-AzKeyVaultSecret -Times 0     # the SP does not exist so we shouldn't be checking for ean existing secret in key vault
+                }
+    
+                It "should update the service principal credential" {
+                    $res.Count | Should -Be 2
+                    $res[0].id | Should -Be '00000000-0000-0000-0000-000000000001'
+                    $res[1] | Should -Be "mock-secret"
+    
+                    Assert-MockCalled New-AzADServicePrincipalCredential -Times 1
+                    Assert-MockCalled _getServicePrincipal -Times 1
+                    Assert-MockCalled New-AzADAppCredential -Times 0
+                    Assert-MockCalled _getApplication -Times 0
+                }
+    
+                It "should not update the key vault secret" {
+                    Assert-MockCalled Set-AzKeyVaultSecret -Times 0
+                }
+            }
+        }
+
+        Context "Using app registration credentials" {
+
+            Describe "Creating a new service principal with default options" {
+
+                Mock Invoke-AzRestMethod { @{ Content = ($mockSp | ConvertTo-Json) } }
+                Mock _newApplication { $mockApp }
+                Mock _getApplication {}
+                Mock _getApplicationForNewAppCredential { $mockApp }
+
+                Mock _getServicePrincipal {}
+    
+                $res = Assert-AzureServicePrincipalForRbac `
+                            -Name "mock-sp" `
+                            -CredentialDisplayName "mock-credential" `
+                            -UseApplicationCredential
+    
+                It "should create a new service principal" {
+                    $res.Count | Should -Be 2
+                    $res[0].id | Should -Be '00000000-0000-0000-0000-000000000001'
+                    $res[1] | Should -Be "mock-secret"
+    
+                    Assert-MockCalled _getApplication -Times 1 -ParameterFilter { $DisplayName -eq 'mock-sp' }
+                    Assert-MockCalled _newApplication -Times 1 -ParameterFilter { $DisplayName -eq 'mock-sp' }
+                    Assert-MockCalled Invoke-AzRestMethod -Times 1 -ParameterFilter { $Uri.EndsWith('servicePrincipals') -and $Method -eq 'POST' -and $Payload -imatch '"appId": "00000000-0000-0000-0000-000000000000"' }
+                }
+    
+                It "should not check for an existing secret in the key vault" {
+                    Assert-MockCalled Get-AzKeyVaultSecret -Times 0     # the SP does not exist so we shouldn't be checking for ean existing secret in key vault
+                }
+    
+                It "should create a new application credential" {
+                    Assert-MockCalled _getApplicationForNewAppCredential -Times 1 -ParameterFilter { $DisplayName -eq 'mock-sp' }
+                    Assert-MockCalled New-AzADServicePrincipalCredential -Times 0
+                    Assert-MockCalled New-AzADAppCredential -Times 1
+                }
+    
+                It "should not update the key vault secret" {
+                    Assert-MockCalled Set-AzKeyVaultSecret -Times 0
+                }
+            }
+    
+            Describe "Updating an existing service principal with default options" {
+    
+                Mock _getServicePrincipal { $mockSp }
+                Mock _getApplication { $mockApp }
+    
+                Mock _newApplication {}
+                Mock _handleCredential {}
+                Mock _newServicePrincipal {}
+    
+                $res = Assert-AzureServicePrincipalForRbac `
+                            -Name "mock-sp" `
+                            -CredentialDisplayName "mock-credential" `
+                            -UseApplicationCredential
+    
+                It "should not create a new service principal" {
+                    Assert-MockCalled _newApplication -Times 0
+                    Assert-MockCalled _newServicePrincipal -Times 0
+                }
+                
+                It "should not check for an existing secret in the key vault" {
+                    Assert-MockCalled Get-AzKeyVaultSecret -Times 0     # the SP does not exist so we shouldn't be checking for ean existing secret in key vault
+                }
+    
+                It "should not update the application credential" {
+                    $res.Count | Should -Be 2
+                    $res[0].id | Should -Be '00000000-0000-0000-0000-000000000001'
+                    $res[1] | Should -Be $null
+    
+                    Assert-MockCalled _getApplication -Times 0
+                    Assert-MockCalled _handleCredential -Times 0
+                }
+    
+                It "should not update the key vault secret" {
+                    Assert-MockCalled Set-AzKeyVaultSecret -Times 0
+                }
+            }
+    
+            Describe "Updating an existing service principal with the 'RotateSecret' option" {
+    
+                Mock _getServicePrincipal { $mockSp }
+                Mock _getApplication { $mockApp }
+    
+                Mock _newApplication {}
+                Mock _newServicePrincipal {}
+    
+                $res = Assert-AzureServicePrincipalForRbac `
+                            -Name "mock-sp" `
+                            -CredentialDisplayName "mock-credential" `
+                            -RotateSecret `
+                            -UseApplicationCredential
+    
+                It "should not create a new service principal" {
+                    Assert-MockCalled _newApplication -Times 0
+                    Assert-MockCalled _newServicePrincipal -Times 0
+                }
+    
+                It "should not check for an existing secret in the key vault" {
+                    Assert-MockCalled Get-AzKeyVaultSecret -Times 0     # the SP does not exist so we shouldn't be checking for ean existing secret in key vault
+                }
+    
+                It "should update the application credential" {
+                    $res.Count | Should -Be 2
+                    $res[0].id | Should -Be '00000000-0000-0000-0000-000000000001'
+                    $res[1] | Should -Be "mock-secret"
+    
+                    Assert-MockCalled _getServicePrincipal -Times 1
+                    Assert-MockCalled New-AzADAppCredential -Times 1
+                    Assert-MockCalled _getApplication -Times 1
+                    Assert-MockCalled New-AzADServicePrincipalCredential -Times 0
+                }
+    
+                It "should not update the key vault secret" {
+                    Assert-MockCalled Set-AzKeyVaultSecret -Times 0
+                }
+            }
+        }
+    }
+
+
+    Context "Key Vault Support" {
+
+        Mock Get-AzKeyVaultSecret { "mock-secret" }
+
+        Context "Using service principal credentials" {
+
+            Describe "Creating a new service principal with default options" {
+
+                Mock Invoke-AzRestMethod { @{ Content = ($mockSp | ConvertTo-Json) } }
+                Mock _newApplication { $mockApp }
+
+                Mock _getApplication {}
+                Mock _getServicePrincipal {}
+
+                $res = Assert-AzureServicePrincipalForRbac `
+                            -Name "mock-sp" `
+                            -CredentialDisplayName "mock-credential" `
+                            -KeyVaultName "mock-keyvault" `
+                            -KeyVaultSecretName "mock-secret-name"
+
+                It "should create a new service principal" {
+                    Assert-MockCalled _newApplication -Times 1 -ParameterFilter { $DisplayName -eq 'mock-sp' }
+                    Assert-MockCalled Invoke-AzRestMethod -Times 1 -ParameterFilter { $Uri.EndsWith('servicePrincipals') -and $Method -eq 'POST' -and $Payload -imatch '"appId": "00000000-0000-0000-0000-000000000000"' }
+                }
+
+                It "should not check for an existing secret in the key vault" {
+                    Assert-MockCalled Get-AzKeyVaultSecret -Times 0     # the SP does not exist so we shouldn't be checking for ean existing secret in key vault
+                }
+
+                It "should create a new service principal credential" {
+                    $res.Count | Should -Be 2
+                    $res[0].id | Should -Be '00000000-0000-0000-0000-000000000001'
+                    $res[1] | Should -Be $null
+
+                    Assert-MockCalled _getApplication -Times 1 -ParameterFilter { $DisplayName -eq 'mock-sp' }
+                    Assert-MockCalled New-AzADServicePrincipalCredential -Times 1
+                    Assert-MockCalled New-AzADAppCredential -Times 0
+                }
+
+                It "should store the secret the key vault" {
+                    Assert-MockCalled Set-AzKeyVaultSecret -Times 1     # the key vault should be updated with new secret
+                }
+            }
+
+            Describe "Update an existing service principal with default options" {
+
+                Mock _getServicePrincipal { $mockSp }
+                Mock _getApplication { $mockApp }
+
+                Mock _newApplication {}
+                Mock _newServicePrincipal {}
+
+                $res = Assert-AzureServicePrincipalForRbac `
+                            -Name "mock-sp" `
+                            -CredentialDisplayName "mock-credential" `
+                            -KeyVaultName "mock-keyvault" `
+                            -KeyVaultSecretName "mock-secret-name"
+
+                It "should not create a new service principal" {
+                    Assert-MockCalled _newApplication -Times 0
+                    Assert-MockCalled _newServicePrincipal -Times 0
+                }
+
+                It "should check for an existing secret in the key vault" {
+                    Assert-MockCalled Get-AzKeyVaultSecret -Times 1     # the SP exists so we should check the key vault
+                }
+
+                It "should not create a new service principal credential" {
+                    $res.Count | Should -Be 2
+                    $res[0].id | Should -Be '00000000-0000-0000-0000-000000000001'
+                    $res[1] | Should -Be $null
+
+                    Assert-MockCalled _getServicePrincipal -Times 1
+                    Assert-MockCalled _getApplication -Times 0
+                    Assert-MockCalled New-AzADServicePrincipalCredential -Times 0
+                    Assert-MockCalled New-AzADAppCredential -Times 0
+                }
+
+                It "should not update the key vault secret" {
+                    Assert-MockCalled Set-AzKeyVaultSecret -Times 0     # the key vault should be updated with new secret
+                }
+            }
+
+            Describe "Update an existing service principal with the 'RotateSecret' option" {
+
+                Mock _getServicePrincipal { $mockSp }
+                Mock _getApplication { $mockApp }
+
+                Mock _newApplication {}
+                Mock _newServicePrincipal {}
+                Mock Get-AzKeyVaultSecret { "mock-secret" }
+
+                $res = Assert-AzureServicePrincipalForRbac `
+                            -Name "mock-sp" `
+                            -CredentialDisplayName "mock-credential" `
+                            -KeyVaultName "mock-keyvault" `
+                            -KeyVaultSecretName "mock-secret-name" `
+                            -RotateSecret
+
+                It "should not create a new service principal" {
+                    Assert-MockCalled _newApplication -Times 0
+                    Assert-MockCalled _newServicePrincipal -Times 0
+                }
+
+                It "should check for an existing secret in the key vault" {
+                    Assert-MockCalled Get-AzKeyVaultSecret -Times 1     # the SP exists so we should check the key vault
+                }
+
+                It "should create a new service principal credential" {
+                    $res.Count | Should -Be 2
+                    $res[0].id | Should -Be '00000000-0000-0000-0000-000000000001'
+                    $res[1] | Should -Be $null
+
+                    Assert-MockCalled _getServicePrincipal -Times 1
+                    Assert-MockCalled _getApplication -Times 0
+                    Assert-MockCalled New-AzADServicePrincipalCredential -Times 1
+                    Assert-MockCalled New-AzADAppCredential -Times 0
+                }
+
+                It "should update the key vault secret" {
+                    Assert-MockCalled Set-AzKeyVaultSecret -Times 1     # the key vault should be updated with new secret
+                }
+            }
+        }
+
+        Context "Using app registration credentials" {
+            Describe "Creating a new service principal with default options" {
+
+                Mock Invoke-AzRestMethod { @{ Content = ($mockSp | ConvertTo-Json) } }
+                Mock _newApplication { $mockApp }
+
+                Mock _getApplicationForNewServicePrincipal {}
+                Mock _getApplicationForNewAppCredential { $mockApp }
+                Mock _getServicePrincipal {}
+
+                $res = Assert-AzureServicePrincipalForRbac `
+                            -Name "mock-sp" `
+                            -CredentialDisplayName "mock-credential" `
+                            -KeyVaultName "mock-keyvault" `
+                            -KeyVaultSecretName "mock-secret-name" `
+                            -UseApplicationCredential
+
+                It "should create a new service principal" {
+                    Assert-MockCalled _getApplicationForNewServicePrincipal -Times 1
+                    Assert-MockCalled _newApplication -Times 1 -ParameterFilter { $DisplayName -eq 'mock-sp' }
+                    Assert-MockCalled Invoke-AzRestMethod -Times 1 -ParameterFilter { $Uri.EndsWith('servicePrincipals') -and $Method -eq 'POST' -and $Payload -imatch '"appId": "00000000-0000-0000-0000-000000000000"' }
+                }
+
+                It "should not check for an existing secret in the key vault" {
+                    Assert-MockCalled Get-AzKeyVaultSecret -Times 0     # the SP does not exist so we shouldn't be checking for ean existing secret in key vault
+                }
+
+                It "should create a new service principal credential" {
+                    $res.Count | Should -Be 2
+                    $res[0].id | Should -Be '00000000-0000-0000-0000-000000000001'
+                    $res[1] | Should -Be $null
+
+                    Assert-MockCalled _getApplicationForNewAppCredential -Times 1 -ParameterFilter { $DisplayName -eq 'mock-sp' }
+                    Assert-MockCalled New-AzADServicePrincipalCredential -Times 0
+                    Assert-MockCalled New-AzADAppCredential -Times 1
+                }
+
+                It "should store the secret the key vault" {
+                    Assert-MockCalled Set-AzKeyVaultSecret -Times 1     # the key vault should be updated with new secret
+                }
+            }
+
+            Describe "Update an existing service principal with default options" {
+
+                Mock _getServicePrincipal { $mockSp }
+                Mock _getApplication { $mockApp }
+
+                Mock _newApplication {}
+                Mock _newServicePrincipal {}
+
+                $res = Assert-AzureServicePrincipalForRbac `
+                            -Name "mock-sp" `
+                            -CredentialDisplayName "mock-credential" `
+                            -KeyVaultName "mock-keyvault" `
+                            -KeyVaultSecretName "mock-secret-name" `
+                            -UseApplicationCredential
+
+                It "should not create a new service principal" {
+                    Assert-MockCalled _newApplication -Times 0
+                    Assert-MockCalled _newServicePrincipal -Times 0
+                }
+
+                It "should check for an existing secret in the key vault" {
+                    Assert-MockCalled Get-AzKeyVaultSecret -Times 1     # the SP exists so we should check the key vault
+                }
+
+                It "should not create a new service principal credential" {
+                    $res.Count | Should -Be 2
+                    $res[0].id | Should -Be '00000000-0000-0000-0000-000000000001'
+                    $res[1] | Should -Be $null
+
+                    Assert-MockCalled _getServicePrincipal -Times 1
+                    Assert-MockCalled _getApplication -Times 0
+                    Assert-MockCalled New-AzADServicePrincipalCredential -Times 0
+                    Assert-MockCalled New-AzADAppCredential -Times 0
+                }
+
+                It "should not update the key vault secret" {
+                    Assert-MockCalled Set-AzKeyVaultSecret -Times 0     # the key vault should be updated with new secret
+                }
+            }
+
+            Describe "Update an existing service principal with the 'RotateSecret' option" {
+
+                Mock _getServicePrincipal { $mockSp }
+                Mock _getApplication { $mockApp }
+
+                Mock _newApplication {}
+                Mock _newServicePrincipal {}
+                Mock Get-AzKeyVaultSecret { "mock-secret" }
+
+                $res = Assert-AzureServicePrincipalForRbac `
+                            -Name "mock-sp" `
+                            -CredentialDisplayName "mock-credential" `
+                            -KeyVaultName "mock-keyvault" `
+                            -KeyVaultSecretName "mock-secret-name" `
+                            -RotateSecret `
+                            -UseApplicationCredential
+
+                It "should not create a new service principal" {
+                    Assert-MockCalled _newApplication -Times 0
+                    Assert-MockCalled _newServicePrincipal -Times 0
+                }
+
+                It "should check for an existing secret in the key vault" {
+                    Assert-MockCalled Get-AzKeyVaultSecret -Times 1     # the SP exists so we should check the key vault
+                }
+
+                It "should create a new service principal credential" {
+                    $res.Count | Should -Be 2
+                    $res[0].id | Should -Be '00000000-0000-0000-0000-000000000001'
+                    $res[1] | Should -Be $null
+
+                    Assert-MockCalled _getServicePrincipal -Times 1
+                    Assert-MockCalled _getApplication -Times 1
+                    Assert-MockCalled New-AzADServicePrincipalCredential -Times 0
+                    Assert-MockCalled New-AzADAppCredential -Times 1
+                }
+
+                It "should update the key vault secret" {
+                    Assert-MockCalled Set-AzKeyVaultSecret -Times 1     # the key vault should be updated with new secret
+                }
+            }
+        }
+    }
+}

--- a/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.Tests.ps1
@@ -5,7 +5,7 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".p
 
 # Make external dependencies available for mocking
 function Get-AzKeyVaultSecret {}
-function Set-AzKeytVaultSecret {}
+function Set-AzKeyVaultSecret {}
 function New-AzADAppCredential { param( [Parameter(ValueFromPipeline = $true)]$ApplicationObject, [Parameter()]$DisplayName, [Parameter()]$EndDate ) }
 function New-AzADServicePrincipalCredential { param( [Parameter(ValueFromPipeline = $true)]$ServicePrincipalObject, [Parameter()]$EndDate ) }
 function Invoke-AzRestMethod { param($Uri, $Method, $Payload) }

--- a/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
+++ b/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
@@ -71,8 +71,10 @@ function Assert-AzureServicePrincipalForRbac
         [switch] $UseApplicationCredential
     )
 
+    $useKeyVault = ($PSCmdlet.ParameterSetName -eq "KeyVault")
+
     # Check whether we have a valid AzPowerShell connection
-    if ($PSCmdlet.ParameterSetName -eq "KeyVault") {
+    if ($useKeyVault) {
         # Subscription access required for key vault integration
         _EnsureAzureConnection -AzPowerShell -ErrorAction Stop | Out-Null
     }
@@ -80,9 +82,6 @@ function Assert-AzureServicePrincipalForRbac
         # No subscription-level access is required
         _EnsureAzureConnection -AzPowerShell -TenantOnly -ErrorAction Stop | Out-Null
     }
-
-    $useKeyVault = ($PSCmdlet.ParameterSetName -eq "KeyVault")
-
 
     $credentialSecret = $null
     $existingSp = _getServicePrincipal -DisplayName $Name
@@ -253,7 +252,7 @@ function Assert-AzureServicePrincipalForRbac
 
         return ($newSp.Content | ConvertFrom-Json -AsHashtable)
     }
-
+    
     # These wrapper functions are required for mocking purposes as '_getApplication' is called in 2 separate scenarios
     function _getApplicationForNewServicePrincipal {
         [CmdletBinding()]

--- a/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
+++ b/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
@@ -96,7 +96,15 @@ function Assert-AzureServicePrincipalForRbac
     }
     #endregion
 
-    _EnsureAzureConnection -AzPowerShell | Out-Null
+    # Check whether we have a valid AzPowerShell connection
+    if ($PSCmdlet.ParameterSetName -eq "KeyVault") {
+        # Subscription access required for key vault integration
+        _EnsureAzureConnection -AzPowerShell -ErrorAction Stop | Out-Null
+    }
+    else {
+        # No subscription-level access is required
+        _EnsureAzureConnection -AzPowerShell -TenantOnly -ErrorAction Stop | Out-Null
+    }
 
     $useKeyVault = ($PSCmdlet.ParameterSetName -eq "KeyVault")
 

--- a/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
+++ b/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
@@ -4,24 +4,31 @@
 
 <#
 .SYNOPSIS
-Ensures that an Azure AD service principal exists, creating if necessary.  Optionally storing the credential
+Ensures that an Azure AD service principal exists, creating if necessary.  Optionally storing the app credential
 in Azure Key Vault.
 
 .DESCRIPTION
-Ensures that a suitable Azure AD application & service principal exists.  Optionally storing the credential
+Ensures that a suitable Azure AD application & service principal exists.  Optionally storing the app credential
 in Azure Key Vault.
 
 .PARAMETER Name
 The display name of the Azure AD service principal.
 
+.PARAMETER CredentialDisplayName
+The label applied to the created/updated credential, which is important for traceability purposes.
+
 .PARAMETER KeyVaultName
-The key vault where that service principal password will be stored.
+The key vault where that client secret will be stored.
 
 .PARAMETER KeyVaultSecretName
-The key vault secret name that service principal password will be stored in.
+The key vault secret name that client secret will be stored in.
 
 .PARAMETER RotateSecret
-When specified, the service principal secret will be regenerated.
+When specified, the client secret will be regenerated.
+
+.PARAMETER UseApplicationCredential
+When specified, the managed credential will be associated with the App registration, otherwise it will be associated
+with the Service Principal object.
 
 .OUTPUTS
 Returns a tuple containing a hashtable representing the object describing the Azure AD service principal and
@@ -39,12 +46,16 @@ e.g.
 function Assert-AzureServicePrincipalForRbac
 {
     [CmdletBinding(SupportsShouldProcess)]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', 'CredentialDisplayName', Justification='Only holds non-sensitive metadata')]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(ParameterSetName = 'Default', Mandatory = $true)]
+        [Parameter(ParameterSetName = 'KeyVault', Mandatory = $true)]
         [string] $Name,
 
-        [Parameter()]
         [int] $PasswordLifetimeDays = 365,
+
+        [Parameter(Mandatory = $true)]
+        [string] $CredentialDisplayName,
         
         [Parameter(ParameterSetName = 'KeyVault',
                     Mandatory = $true)]
@@ -54,47 +65,11 @@ function Assert-AzureServicePrincipalForRbac
                     Mandatory = $true)]
         [string] $KeyVaultSecretName,
 
-        [Parameter(ParameterSetName = 'KeyVault')]
-        [switch] $RotateSecret
+        [switch] $RotateSecret,
+
+        [Parameter()]
+        [switch] $UseApplicationCredential
     )
-
-    #region internal helper functions
-    function _handleCredential {
-        [CmdletBinding()]
-        param (
-            [Parameter(Mandatory=$true)]
-            $ServicePrincipal
-        )
-
-        # Generate a new service principal secret
-        $spCred = $ServicePrincipal | New-AzADServicePrincipalCredential -EndDate ([DateTime]::Now.AddDays($PasswordLifetimeDays))
-
-        # Get the secret from the credential object, based on which graph API we're using
-        $spAddId = $useMsGraph ? $ServicePrincipal.AppId : $ServicePrincipal.ApplicationId
-        $spPassword = $useMsGraph `
-                            ? $spCred.SecretText `
-                            : ($spCred.Secret | ConvertFrom-SecureString -AsPlainText)
-
-        if ($useKeyVault) {
-            $spLoginDetails = @{
-                appId = $spAddId
-                password = $spPassword
-                tenant = (Get-AzContext).Tenant.Id
-            }
-            Write-Host "Storing service principal secret in key vault [VaultName=$KeyVaultName, SecretName=$KeyVaultSecretName]"
-            Set-AzKeyVaultSecret -VaultName $KeyVaultName `
-                                 -Name $KeyVaultSecretName `
-                                 -SecretValue ($spLoginDetails | ConvertTo-Json | ConvertTo-SecureString -AsPlainText -Force) `
-                                 -ContentType "application/json" `
-                | Out-Null
-
-            return $null
-        }
-        else {
-            return (ConvertFrom-SecureString $spCredential -AsPlainText)
-        }
-    }
-    #endregion
 
     # Check whether we have a valid AzPowerShell connection
     if ($PSCmdlet.ParameterSetName -eq "KeyVault") {
@@ -108,22 +83,9 @@ function Assert-AzureServicePrincipalForRbac
 
     $useKeyVault = ($PSCmdlet.ParameterSetName -eq "KeyVault")
 
-    # Handle Azure Graph -> MS Graph transition
-    # Breaking change to property names between v4 and v5 of the module
-    $useMsGraph = $true
-    $azResourcesModule = Import-Module Az.Resources -PassThru -Verbose:$false
-    if ($azResourcesModule.Version.Major -gt 4) {
-        Write-Verbose "Using Microsoft Graph"
-        $appIdPropertyName = "AppId"
-    }
-    else {
-        Write-Verbose "Using Azure Graph"
-        $appIdPropertyName = "ApplicationId"
-        $useMsGraph = $false
-    }
 
-    $spSecret = $null
-    $existingSp = Get-AzADServicePrincipal -DisplayName $Name
+    $credentialSecret = $null
+    $existingSp = _getServicePrincipal -DisplayName $Name
 
     if (!$existingSp) {
         if ($PSCmdlet.ShouldProcess($Name, "Create Service Principal")) {
@@ -132,37 +94,183 @@ function Assert-AzureServicePrincipalForRbac
             $createParams = @{
                 DisplayName = $Name
             }
-            if (!$useMsGraph) {
-                $createParams += @{ SkipAssignment = $true }
-            }
-            $newSp = New-AzADServicePrincipal @createParams
-            Write-Host ("Created service principal [ObjectId={0}, ApplicationId={1}]" -f $newSp.Id, $newSp.$appIdPropertyName)
+            $newSp = _newServicePrincipal @createParams
+            Write-Host ("Created service principal [ObjectId={0}, ApplicationId={1}]" -f $newSp.Id, $newSp.appId)
             
-            # Delete the default credential
-            Get-AzADServicePrincipalCredential -DisplayName $Name | Remove-AzADServicePrincipalCredential
-            # Setup the credential and store it in key vault, if necessary
-            $spSecret = _handleCredential $newSp
+            # Setup the client secret/credential and store it in key vault, if necessary
+            if ($UseApplicationCredential) {
+                $app = _getApplicationForNewAppCredential -DisplayName $Name
+                $handleCredSplat = @{ Application = $app }
+            }
+            else {
+                $handleCredSplat = @{ ServicePrincipal = $newSp }
+            }
+            $credentialSecret = _handleCredential @handleCredSplat -UseKeyVault $useKeyVault
         }
     }
     else {
         Write-Host ("Service Principal '{0}' already exists [ObjectId={1}, ApplicationId={2}]" -f `
                             $Name,
                             $existingSp.Id,
-                            $existingSp.$appIdPropertyName)
+                            $existingSp.appId)
 
         if ($useKeyVault) {
             # if using key vault, check whether the specified secret is available
             $existingSecret = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $KeyVaultSecretName
         }
 
-        # rotate the secret
+        # rotate the client secret/credential 
         if (($useKeyVault -and !$existingSecret) -or $RotateSecret) {
             if ($PSCmdlet.ShouldProcess($Name, "Rotate Service Principal Secret")) {
                 Write-Host "Rotating service principal credential [UseKeyVault=$useKeyVault, KeyVaultSecretMissing=$(!$existingSecret), RotateFlag=$RotateSecret]"
-                $spSecret = _handleCredential $existingSp
+                if ($UseApplicationCredential) {
+                    $app = _getApplicationForNewAppCredential -DisplayName $Name
+                    $handleCredSplat = @{ Application = $app }
+                }
+                else {
+                    $handleCredSplat = @{ ServicePrincipal = $existingSp }
+                }
+
+                $credentialSecret = _handleCredential @handleCredSplat -UseKeyVault $useKeyVault
             }
         }
     }
 
-    return ($existingSp ? $existingSp : $newSp),$spSecret
+    return ($existingSp ? $existingSp : $newSp),$credentialSecret
 }
+
+    #region Helper functions internal to the module
+    function _handleCredential {
+        [CmdletBinding()]
+        param (
+            [Parameter(Mandatory=$true, ParameterSetName="Application")]
+            [hashtable] $Application,
+
+            [Parameter(Mandatory=$true, ParameterSetName="ServicePrincipal")]
+            [hashtable] $ServicePrincipal,
+
+            [Parameter()]
+            [bool] $UseKeyVault
+        )
+
+        if ($PSCmdlet.ParameterSetName -eq "Application") {
+            Write-Verbose "Credential will be associated with the App registration"
+            # Generate a new secret attached to the application registration
+            $newCred = $Application | New-AzADAppCredential `
+                            -EndDate ([DateTime]::Now.AddDays($PasswordLifetimeDays)) `
+                            -DisplayName $CredentialDisplayName
+        }
+        else {
+            # Generate a new secret attached to the service principal
+            Write-Verbose "Credential will be associated with the Service Principal"
+            $newCred = $ServicePrincipal | New-AzADServicePrincipalCredential `
+                            -EndDate ([DateTime]::Now.AddDays($PasswordLifetimeDays))
+        }
+        
+
+        if ($UseKeyVault) {
+            $appLoginDetails = @{
+                appId = $Application.appId
+                password = $newCred.SecretText
+                tenant = (Get-AzContext).Tenant.Id
+            }
+            Write-Host "Storing client secret in key vault [VaultName=$KeyVaultName, SecretName=$KeyVaultSecretName]"
+            Set-AzKeyVaultSecret -VaultName $KeyVaultName `
+                                 -Name $KeyVaultSecretName `
+                                 -SecretValue ($appLoginDetails | ConvertTo-Json | ConvertTo-SecureString -AsPlainText -Force) `
+                                 -ContentType "application/json" `
+                | Out-Null
+
+            return $null
+        }
+        else {
+            return (ConvertFrom-SecureString $newCred.SecretText -AsPlainText)
+        }
+    }
+    function _getApplication {
+        [CmdletBinding()]
+        param (
+            [Parameter(Mandatory=$true)]
+            $DisplayName
+        )
+
+        $resp = Invoke-AzRestMethod -Uri "https://graph.microsoft.com/v1.0/applications?`$filter=displayName eq '$DisplayName'"
+        $app = $resp.Content |
+                    ConvertFrom-Json -AsHashtable -Depth 100 |
+                    Select-Object -ExpandProperty value
+
+        return $app
+    }
+    function _newApplication {
+        [CmdletBinding()]
+        param (
+            [Parameter(Mandatory=$true)]
+            $DisplayName
+        )
+
+        $payload = @{ displayName = $DisplayName}
+        $resp = Invoke-AzRestMethod -Uri "https://graph.microsoft.com/v1.0/applications" `
+                                    -Method POST `
+                                    -Payload ($payload | ConvertTo-Json)
+        $newAppp = $resp.Content |
+                ConvertFrom-Json -AsHashtable
+
+        return $newApp
+    }
+    function _getServicePrincipal {
+        [CmdletBinding()]
+        param (
+            [Parameter(Mandatory=$true)]
+            $DisplayName
+        )
+
+        $resp = Invoke-AzRestMethod -Uri "https://graph.microsoft.com/v1.0/servicePrincipals?`$filter=displayName eq '$DisplayName'"
+        $sp = $resp.Content |
+                    ConvertFrom-Json -AsHashtable -Depth 100 |
+                    Select-Object -ExpandProperty value
+
+        return $sp
+    }
+    function _newServicePrincipal {
+        [CmdletBinding()]
+        param (
+            [Parameter(Mandatory=$true)]
+            $DisplayName
+        )
+
+        # Check whether an application object already exists with this display name
+        $app = _getApplicationForNewServicePrincipal @PSBoundParameters
+        if (!$app) {
+            # Create a bare application registration, as the appId
+            $app = _newApplication @PSBoundParameters
+        }
+
+        # Create the service principal
+        $payload = @{ appId = $app.appId}
+        $newSp = Invoke-AzRestMethod -Uri "https://graph.microsoft.com/v1.0/servicePrincipals" `
+                                     -Method POST `
+                                     -Payload ($payload | ConvertTo-Json)
+
+        return ($newSp.Content | ConvertFrom-Json -AsHashtable)
+    }
+
+    # These wrapper functions are required for mocking purposes as '_getApplication' is called in 2 separate scenarios
+    function _getApplicationForNewServicePrincipal {
+        [CmdletBinding()]
+        param (
+            [Parameter(Mandatory=$true)]
+            $DisplayName
+        )
+
+        _getApplication @PSBoundParameters
+    }
+    function _getApplicationForNewAppCredential {
+        [CmdletBinding()]
+        param (
+            [Parameter(Mandatory=$true)]
+            $DisplayName
+        )
+
+        _getApplication @PSBoundParameters
+    }
+    #endregion

--- a/module/functions/azure/aad/Get-AzureAdDirectoryObject.Tests.ps1
+++ b/module/functions/azure/aad/Get-AzureAdDirectoryObject.Tests.ps1
@@ -1,0 +1,197 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".ps1")
+
+. "$here\$sut"
+
+Describe "Get-AzureAdDirectoryObject Tests" {
+
+    # Setup some mock AzureAD objects
+    $mockGroup = @{
+        ObjectId = '5c21a713-c12c-4592-807e-e45b1adc8634'
+        DisplayName = 'Mock Group'
+    }
+    $mockServicePrincipal = @{
+        ObjectId = '308d6796-5639-49da-a0b4-17e37de6e4de'
+        ApplicationId = 'c6c60257-7088-41b0-a8b3-6cdfe22c4855'
+        DisplayName = 'Mock Service Principal'
+    }
+    $mockUser = @{
+        ObjectId = '5f3c6343-88e8-4888-afcd-2a7acfaa7fc7'
+        DisplayName = 'Mock User'
+        UserPrincipalName = 'mock.user@nowhere.org'
+    }
+
+    # Mock out the calls to AzureAD, intercepting those that need to simulate a matching result
+    Mock _groupById { $global:methodUsed="ObjectId"; $mockGroup } -ParameterFilter { $ObjectId -eq $mockGroup.ObjectId }
+    Mock _groupById {}
+    Mock _groupByName { $global:methodUsed="DisplayName"; $mockGroup } -ParameterFilter { $DisplayName -eq $mockGroup.DisplayName }
+    Mock _groupByName {}
+    Mock _spByAppId { $global:methodUsed="ApplicationId"; $mockServicePrincipal } -ParameterFilter { $ApplicationId -eq $mockServicePrincipal.ApplicationId }
+    Mock _spByAppId {}
+    Mock _spByObjectId { $global:methodUsed="ObjectId"; $mockServicePrincipal } -ParameterFilter { $ObjectId -eq $mockServicePrincipal.ObjectId }
+    Mock _spByObjectId {}
+    Mock _spByName { $global:methodUsed="DisplayName"; $mockServicePrincipal } -ParameterFilter { $DisplayName -eq $mockServicePrincipal.DisplayName }
+    Mock _spByName {}
+    Mock _userById { $global:methodUsed="ObjectId"; $mockUser } -ParameterFilter { $ObjectId -eq $mockUser.ObjectId }
+    Mock _userById {}
+    Mock _userByName { $global:methodUsed="DisplayName"; $mockUser } -ParameterFilter { $DisplayName -eq $mockUser.DisplayName }
+    Mock _userByName {}
+    Mock _userByUpn { $global:methodUsed="UserPrincipalName"; $mockUser } -ParameterFilter { $UserPrincipalName -eq $mockUser.UserPrincipalName }
+    Mock _userByUpn {}
+
+    Mock Write-Verbose {}
+    Mock Write-Warning {}
+
+    Context "Finding a group" {
+
+        Context "Searching by ObjectId" {
+            $global:methodUsed = $null
+            $res = Get-AzureAdDirectoryObject -Criterion $mockGroup.ObjectId
+            
+            It "should return the group" {
+                $methodUsed | Should -Be "ObjectId"
+                $res.DisplayName | Should -Be $mockGroup.DisplayName
+                
+                Assert-MockCalled _groupById -Times 1
+                Assert-MockCalled _spByAppId -Times 1
+                Assert-MockCalled _spByObjectId -Times 1
+                Assert-MockCalled _userById -Times 1
+                Assert-MockCalled _groupByName -Times 0
+                Assert-MockCalled _spByName -Times 0
+                Assert-MockCalled _userByName -Times 0
+            }
+        }
+
+        Context "Searching by DisplayName" {
+            $global:methodUsed = $null
+            $res = Get-AzureAdDirectoryObject -Criterion $mockGroup.DisplayName
+            
+            It "should return the group" {
+                $methodUsed | Should -Be "DisplayName"
+                $res.ObjectId | Should -Be $mockGroup.ObjectId
+                
+                Assert-MockCalled _groupById -Times 0
+                Assert-MockCalled _spByAppId -Times 0
+                Assert-MockCalled _spByObjectId -Times 0
+                Assert-MockCalled _userById -Times 0
+                Assert-MockCalled _groupByName -Times 1
+                Assert-MockCalled _spByName -Times 1
+                Assert-MockCalled _userByName -Times 1
+            }
+        }
+    }
+
+    Context "Finding a service principal" {
+
+        Context "Searching by ObjectId" {
+            $global:methodUsed = $null
+            $res = Get-AzureAdDirectoryObject -Criterion $mockServicePrincipal.ObjectId
+            
+            It "should return the group" {
+                $methodUsed | Should -Be "ObjectId"
+                $res.DisplayName | Should -Be $mockServicePrincipal.DisplayName
+                
+                Assert-MockCalled _groupById -Times 1
+                Assert-MockCalled _spByAppId -Times 1
+                Assert-MockCalled _spByObjectId -Times 1
+                Assert-MockCalled _userById -Times 1
+                Assert-MockCalled _groupByName -Times 0
+                Assert-MockCalled _spByName -Times 0
+                Assert-MockCalled _userByName -Times 0
+            }
+        }
+
+        Context "Searching by ApplicationId" {
+            $global:methodUsed = $null
+            $res = Get-AzureAdDirectoryObject -Criterion $mockServicePrincipal.ApplicationId
+            
+            It "should return the group" {
+                $methodUsed | Should -Be "ApplicationId"
+                $res.DisplayName | Should -Be $mockServicePrincipal.DisplayName
+                
+                Assert-MockCalled _groupById -Times 1
+                Assert-MockCalled _spByAppId -Times 1
+                Assert-MockCalled _spByObjectId -Times 1
+                Assert-MockCalled _userById -Times 1
+                Assert-MockCalled _groupByName -Times 0
+                Assert-MockCalled _spByName -Times 0
+                Assert-MockCalled _userByName -Times 0
+            }
+        }
+
+        Context "Searching by DisplayName" {
+            $global:methodUsed = $null
+            $res = Get-AzureAdDirectoryObject -Criterion $mockServicePrincipal.DisplayName
+            
+            It "should return the group" {
+                $methodUsed | Should -Be "DisplayName"
+                $res.ObjectId | Should -Be $mockServicePrincipal.ObjectId
+                
+                Assert-MockCalled _groupById -Times 0
+                Assert-MockCalled _spByAppId -Times 0
+                Assert-MockCalled _spByObjectId -Times 0
+                Assert-MockCalled _userById -Times 0
+                Assert-MockCalled _groupByName -Times 1
+                Assert-MockCalled _spByName -Times 1
+                Assert-MockCalled _userByName -Times 1
+            }
+        }
+    }
+
+    Context "Finding a user" {
+
+        Context "Searching by ObjectId" {
+            $global:methodUsed = $null
+            $res = Get-AzureAdDirectoryObject -Criterion $mockUser.ObjectId
+            
+            It "should return the group" {
+                $methodUsed | Should -Be "ObjectId"
+                $res.DisplayName | Should -Be $mockUser.DisplayName
+                
+                Assert-MockCalled _groupById -Times 1
+                Assert-MockCalled _spByAppId -Times 1
+                Assert-MockCalled _spByObjectId -Times 1
+                Assert-MockCalled _userById -Times 1
+                Assert-MockCalled _groupByName -Times 0
+                Assert-MockCalled _spByName -Times 0
+                Assert-MockCalled _userByName -Times 0
+            }
+        }
+
+        Context "Searching by DisplayName" {
+            $global:methodUsed = $null
+            $res = Get-AzureAdDirectoryObject -Criterion $mockUser.DisplayName
+            
+            It "should return the group" {
+                $methodUsed | Should -Be "DisplayName"
+                $res.ObjectId | Should -Be $mockUser.ObjectId
+                
+                Assert-MockCalled _groupById -Times 0
+                Assert-MockCalled _spByAppId -Times 0
+                Assert-MockCalled _spByObjectId -Times 0
+                Assert-MockCalled _userById -Times 0
+                Assert-MockCalled _groupByName -Times 1
+                Assert-MockCalled _spByName -Times 1
+                Assert-MockCalled _userByName -Times 1
+            }
+        }
+
+        Context "Searching by UPN" {
+            $global:methodUsed = $null
+            $res = Get-AzureAdDirectoryObject -Criterion $mockUser.UserPrincipalName
+            
+            It "should return the group" {
+                $methodUsed | Should -Be "UserPrincipalName"
+                $res.ObjectId | Should -Be $mockUser.ObjectId
+                
+                Assert-MockCalled _groupById -Times 0
+                Assert-MockCalled _spByAppId -Times 0
+                Assert-MockCalled _spByObjectId -Times 0
+                Assert-MockCalled _userById -Times 0
+                Assert-MockCalled _groupByName -Times 1
+                Assert-MockCalled _spByName -Times 1
+                Assert-MockCalled _userByName -Times 1
+            }
+        }
+    }
+}

--- a/module/functions/azure/aad/Get-AzureAdDirectoryObject.Tests.ps1
+++ b/module/functions/azure/aad/Get-AzureAdDirectoryObject.Tests.ps1
@@ -3,7 +3,12 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".p
 
 . "$here\$sut"
 
+# define other functions that will be mocked
+function _EnsureAzureConnection {}
+
 Describe "Get-AzureAdDirectoryObject Tests" {
+
+    function _EnsureAzureConnection { $true }
 
     # Setup some mock AzureAD objects
     $mockGroup = @{

--- a/module/functions/azure/aad/Get-AzureAdDirectoryObject.Tests.ps1
+++ b/module/functions/azure/aad/Get-AzureAdDirectoryObject.Tests.ps1
@@ -92,7 +92,7 @@ Describe "Get-AzureAdDirectoryObject Tests" {
             $global:methodUsed = $null
             $res = Get-AzureAdDirectoryObject -Criterion $mockServicePrincipal.ObjectId
             
-            It "should return the group" {
+            It "should return the service principal" {
                 $methodUsed | Should -Be "ObjectId"
                 $res.DisplayName | Should -Be $mockServicePrincipal.DisplayName
                 
@@ -110,7 +110,7 @@ Describe "Get-AzureAdDirectoryObject Tests" {
             $global:methodUsed = $null
             $res = Get-AzureAdDirectoryObject -Criterion $mockServicePrincipal.ApplicationId
             
-            It "should return the group" {
+            It "should return the service principal" {
                 $methodUsed | Should -Be "ApplicationId"
                 $res.DisplayName | Should -Be $mockServicePrincipal.DisplayName
                 
@@ -128,7 +128,7 @@ Describe "Get-AzureAdDirectoryObject Tests" {
             $global:methodUsed = $null
             $res = Get-AzureAdDirectoryObject -Criterion $mockServicePrincipal.DisplayName
             
-            It "should return the group" {
+            It "should return the service principal" {
                 $methodUsed | Should -Be "DisplayName"
                 $res.ObjectId | Should -Be $mockServicePrincipal.ObjectId
                 
@@ -149,7 +149,7 @@ Describe "Get-AzureAdDirectoryObject Tests" {
             $global:methodUsed = $null
             $res = Get-AzureAdDirectoryObject -Criterion $mockUser.ObjectId
             
-            It "should return the group" {
+            It "should return the user" {
                 $methodUsed | Should -Be "ObjectId"
                 $res.DisplayName | Should -Be $mockUser.DisplayName
                 
@@ -167,7 +167,7 @@ Describe "Get-AzureAdDirectoryObject Tests" {
             $global:methodUsed = $null
             $res = Get-AzureAdDirectoryObject -Criterion $mockUser.DisplayName
             
-            It "should return the group" {
+            It "should return the user" {
                 $methodUsed | Should -Be "DisplayName"
                 $res.ObjectId | Should -Be $mockUser.ObjectId
                 
@@ -185,7 +185,7 @@ Describe "Get-AzureAdDirectoryObject Tests" {
             $global:methodUsed = $null
             $res = Get-AzureAdDirectoryObject -Criterion $mockUser.UserPrincipalName
             
-            It "should return the group" {
+            It "should return the user" {
                 $methodUsed | Should -Be "UserPrincipalName"
                 $res.ObjectId | Should -Be $mockUser.ObjectId
                 

--- a/module/functions/azure/aad/Get-AzureAdDirectoryObject.ps1
+++ b/module/functions/azure/aad/Get-AzureAdDirectoryObject.ps1
@@ -1,0 +1,170 @@
+# <copyright file="Assert-AzureAdGroupMembership.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+<#
+.SYNOPSIS
+Searches the different types of AzureAD directory objects to find a match for the specified criterion.
+
+.DESCRIPTION
+Searches for groups, service principals and users in AzureAD that match the specified criteria.
+
+.PARAMETER Criterion
+When a GUID, will be compared with the ApplicationId and/or ObjectId properties of the relevant AzureAD directory objects. Non-GUID values will
+be queried as exact matches against the 'DisplayName' property.
+
+.PARAMETER Single
+When true, an exception will be thrown if multiple matches are found.
+
+.PARAMETER SuppressMultipleMatchWarning
+When true, no warnings will be logged if multiple matches are found.
+
+#>
+
+function Get-AzureAdDirectoryObject {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [string] $Criterion,
+
+        [switch] $Single,
+
+        [switch] $SuppressMultipleMatchWarning
+    )
+
+    # These are the methods that run the AzureAD queries based on GUID based criteria
+    [scriptblock[]]$lookupMethodsById = @(
+        { _groupById -ObjectId $args[0] }
+        { _spByAppId -ApplicationId $args[0] }
+        { _spByObjectId -ObjectId $args[0] }
+        { _userById -ObjectId $args[0] }
+    )
+    # These are the methods that run the AzureAD queries based on non-GUID based criteria
+    [scriptblock[]]$lookupMethodsByName = @(
+        { _groupByName -DisplayName $args[0] }
+        { _spByName -DisplayName $args[0] }
+        { _userByName -DisplayName $args[0] }
+        { _userByUpn -UserPrincipalName $args[0] }
+    )
+
+    $matchesFound = @()
+    try {
+        # Attempt queries by ObjectId/ApplicationId - if the Criteria isn't a GUID then this block will be skipped due to the casting exception
+        $memberGuid = [guid]$Criterion
+        foreach ($lookupMethod in $lookupMethodsById) {
+            try {
+                $directoryObject = Invoke-Command $lookupMethod -ArgumentList @($memberGuid)
+                if ($directoryObject) {
+                    $matchesFound += $directoryObject
+                }
+            }
+            catch {}
+        }
+    }
+    catch {
+        # Atrtempt queries by DisplayName/UPN
+        foreach ($lookupMethod in $lookupMethodsByName) {
+            try {
+                $directoryObject = Invoke-Command $lookupMethod -ArgumentList @($Criterion)
+                if ($directoryObject) {
+                    $matchesFound += $directoryObject
+                }
+            }
+            catch {}
+        }
+    }
+
+    # Parse any matching results
+    if ($matchesFound.Count -gt 1) {
+        $multiMatchOutput = $matchesFound | ForEach-Object {
+            "`t{0}`t{1}`t{2}`n" -f `
+                $_.GetType().Name,
+                $_.DisplayName,
+                $_.Id
+        }
+        if (!$SuppressMultipleMatchWarning) {
+            Write-Warning "Found multiple matching directory objects, when expecting a single result:`n$multiMatchOutput"
+        }
+
+        if ($Single) {
+            throw "Found multiple matching directory objects when expecting a single results - check previous log messages for details"
+        }
+    }
+    
+    return $matchesFound
+}
+
+#
+# These functions handle the underlying AzureAD queries and allow us to mock-out the
+# AzureAD connectivity in our tests
+#
+function _groupById {
+    param($ObjectId)
+    # Look-ups via ObjectId will error when no matches are found
+    $res = Get-AzAdGroup -ObjectId $ObjectId -ErrorAction Stop
+    Write-Verbose "Found Group by ObjectId"
+    $res
+}
+function _spByAppId {
+    param($ApplicationId)
+    # Look-ups via ApplicationId return null when no matches are found
+    $res = Get-AzADServicePrincipal -ApplicationId $ApplicationId -ErrorAction Stop
+    if ($res) {
+        Write-Verbose "Found Service Principal by ApplicationId"
+    }
+    $res
+}
+function _spByObjectId {
+    param($ObjectId)
+    # Look-ups via ObjectId will error when no matches are found
+    $res = Get-AzADServicePrincipal -ObjectId $ObjectId -ErrorAction Stop
+    Write-Verbose "Found Service Principal by ObjectId"
+    $res
+}
+function _userById {
+    param($ObjectId)
+    # Look-ups via ObjectId will error when no matches are found
+    $res = Get-AzAdUser -ObjectId $ObjectId -ErrorAction Stop
+    Write-Verbose "Found User by ObjectId"
+    $res
+}
+
+function _groupByName {
+    param($DisplayName)
+    # Look-ups via DisplayName return null when no matches are found
+    $res = Get-AzAdGroup -DisplayName $DisplayName -ErrorAction Stop
+    if ($res) {
+        Write-Verbose "Found Group by Name"
+    }
+    $res
+}
+function _spByName {
+    param($DisplayName)
+    # Look-ups via DisplayName return null when no matches are found
+    $res = Get-AzADServicePrincipal -DisplayName $DisplayName -ErrorAction Stop
+    if ($res) {
+        Write-Verbose "Found Service Principal by Name"
+    }
+    $res
+}
+function _userByName {
+    param($DisplayName)
+    # Look-ups via DisplayName return null when no matches are found
+    $res = Get-AzAdUser -DisplayName $DisplayName -ErrorAction Stop
+    if ($res) {
+        Write-Verbose "Found User by Name"
+    }
+    $res
+}
+function _userByUpn {
+    param($UserPrincipalName)
+    # Look-ups via UserPrincipalName return null when no matches are found
+    $res = $null
+    if ($UserPrincipalName -match "@") {
+        $res = Get-AzAdUser -UserPrincipalName $UserPrincipalName -ErrorAction Stop
+        if ($res) {
+            Write-Verbose "Found User by UserPrincipalName"
+        }
+    }
+    $res
+} 

--- a/module/functions/azure/aad/Get-AzureAdDirectoryObject.ps1
+++ b/module/functions/azure/aad/Get-AzureAdDirectoryObject.ps1
@@ -32,7 +32,8 @@ function Get-AzureAdDirectoryObject {
         [switch] $SuppressMultipleMatchWarning
     )
 
-    _EnsureAzureConnection -AzPowerShell | Out-Null
+    # Check whether we have a valid AzPowerShell connection, but no subscription-level access is required
+    _EnsureAzureConnection -AzPowerShell -TenantOnly -ErrorAction Stop | Out-Null
 
     # These are the methods that run the AzureAD queries based on GUID based criteria
     [scriptblock[]]$lookupMethodsById = @(

--- a/module/functions/azure/aad/Get-AzureAdDirectoryObject.ps1
+++ b/module/functions/azure/aad/Get-AzureAdDirectoryObject.ps1
@@ -32,6 +32,8 @@ function Get-AzureAdDirectoryObject {
         [switch] $SuppressMultipleMatchWarning
     )
 
+    _EnsureAzureConnection -AzPowerShell | Out-Null
+
     # These are the methods that run the AzureAD queries based on GUID based criteria
     [scriptblock[]]$lookupMethodsById = @(
         { _groupById -ObjectId $args[0] }

--- a/module/functions/azure/aad/Test-AzureGraphAccess.ps1
+++ b/module/functions/azure/aad/Test-AzureGraphAccess.ps1
@@ -19,8 +19,8 @@ function Test-AzureGraphAccess
     (
     )
 
-    # Check whether we have a valid AzPowerShell connection
-    _EnsureAzureConnection -AzPowerShell -ErrorAction Stop
+    # Check whether we have a valid AzPowerShell connection, but no subscription-level access is required
+    _EnsureAzureConnection -AzPowerShell -TenantOnly -ErrorAction Stop | Out-Null
     
     # perform an arbitrary AAD operation to see if we have read access to the graph API
     try {

--- a/module/functions/azure/azcli/Assert-AzCliLogin.ps1
+++ b/module/functions/azure/azcli/Assert-AzCliLogin.ps1
@@ -19,6 +19,10 @@ The target Azure Subscription ID.
 .PARAMETER AadTenantId
 The AzureAD Tenant ID associated with subscription.
 
+.PARAMETER TenantOnly
+When true, the connection will not be attached to a subscription. This is useful when working with
+identities that have no permissions to Azure resources (e.g. used only for Azure Active Directory automation).
+
 .OUTPUTS
 Returns the details of the logged-in account (i.e. the output from 'az account show').
 
@@ -50,8 +54,12 @@ function Assert-AzCliLogin {
         }
     }
     catch {
+        $requiredEnvVarsForAutoLogin = (
+            ![string]::IsNullOrEmpty($env:AZURE_CLIENT_ID) -and `
+            ![string]::IsNullOrEmpty($env:AZURE_CLIENT_SECRET)
+        )
         # login with the typical environment variables, if available
-        if ( (Test-Path env:\AZURE_CLIENT_ID) -and (Test-Path env:\AZURE_CLIENT_SECRET) ) {
+        if ($requiredEnvVarsForAutoLogin) {
             Write-Host "Performing azure-cli login as service principal via environment variables"
             $azCliParams = @(
                 "login"

--- a/module/functions/azure/azcli/Assert-AzCliLogin.ps1
+++ b/module/functions/azure/azcli/Assert-AzCliLogin.ps1
@@ -24,14 +24,27 @@ Returns the details of the logged-in account (i.e. the output from 'az account s
 
 #>
 function Assert-AzCliLogin {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName="Default")]
     param (
-        [Parameter(Mandatory=$true)] [string] $SubscriptionId,
-        [Parameter(Mandatory=$true)] [string] $AadTenantId
+        [Parameter(ParameterSetName="Default", Mandatory=$true)]
+        [string] $SubscriptionId,
+
+        [Parameter(Mandatory=$true)]
+        [string] $AadTenantId,
+
+        [Parameter(ParameterSetName="TenantOnly", Mandatory=$true)]
+        [switch] $TenantOnly
     )
+
     try {
         # check whether already logged-in
-        [datetime]$currentTokenExpiry = & az account get-access-token --subscription $SubscriptionId -o tsv --query "expiresOn" 2>&1
+        if ($TenantOnly) {
+            [datetime]$currentTokenExpiry = & az account get-access-token -o tsv --query "expiresOn" 2>&1
+        }
+        else {
+            [datetime]$currentTokenExpiry = & az account get-access-token --subscription $SubscriptionId -o tsv --query "expiresOn" 2>&1
+        }
+        
         if ($currentTokenExpiry -le [datetime]::Now) {
             throw
         }
@@ -40,18 +53,31 @@ function Assert-AzCliLogin {
         # login with the typical environment variables, if available
         if ( (Test-Path env:\AZURE_CLIENT_ID) -and (Test-Path env:\AZURE_CLIENT_SECRET) ) {
             Write-Host "Performing azure-cli login as service principal via environment variables"
-            Invoke-AzCli -Command ('login --service-principal -u "{0}" -p "{1}" --tenant $AadTenantId' -f $env:AZURE_CLIENT_ID, $env:AZURE_CLIENT_SECRET) `
+            $azCliParams = @(
+                "login"
+                "--service-principal"
+                "-u `"{0}`"" -f $env:AZURE_CLIENT_ID
+                "-p `"{1}`"" -f $env:AZURE_CLIENT_SECRET
+                "--tenant $AadTenantId"
+            )
+            if ($TenantOnly) {
+                $azCliParams += "--allow-no-subscriptions"
+            }
+            Invoke-AzCli -Command $azCliParams `
                          -SuppressConnectionValidation
         }
         # Azure pipeline processes seem to report themselves as interactive - at least on linux agents
         elseif ( [Environment]::UserInteractive -and !(Test-Path env:\SYSTEM_TEAMFOUNDATIONSERVERURI) ) {
-            Invoke-AzCli -Command "login --tenant $AadTenantId" -SuppressConnectionValidation
+            Invoke-AzCli -Command "login --tenant $AadTenantId" `
+                         -SuppressConnectionValidation
         }
         else {
             Write-Error "When running non-interactively the process must already be logged-in to the Azure-cli or have the SPN details setup in environment variables"
         }
     }
 
-    Invoke-AzCli "account set --subscription $SubscriptionId" -SuppressConnectionValidation
+    if (!$TenantOnly) {
+        Invoke-AzCli "account set --subscription $SubscriptionId" -SuppressConnectionValidation
+    }
     return (Invoke-AzCli "account show" -asJson -SuppressConnectionValidation)
 }

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -2,6 +2,9 @@ $ErrorActionPreference = 'Stop'
 $here = Split-Path -Parent $PSCommandPath
 $pesterVer = '4.10.1'
 try {
+    # Display what version of Azure PowerShell we have available
+    Get-Module Az.Resources -ListAvailable | Format-Table | Out-string | Write-Host
+
     [array]$existingModule = Get-Module -ListAvailable Pester
     if (!$existingModule -or ($existingModule.Version -notcontains $pesterVer)) {
         Install-Module Pester -RequiredVersion $pesterVer -Force -Scope CurrentUser -SkipPublisherCheck

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -2,11 +2,6 @@ $ErrorActionPreference = 'Stop'
 $here = Split-Path -Parent $PSCommandPath
 $pesterVer = '4.10.1'
 try {
-    # Display what version of Azure PowerShell we have available
-    Write-Host "Checking Az PowerShell module versions..."
-    Get-Module Az -ListAvailable | Format-Table | Out-string | Write-Host
-    Get-Module Az.Resources -ListAvailable | Format-Table | Out-string | Write-Host
-
     [array]$existingModule = Get-Module -ListAvailable Pester
     if (!$existingModule -or ($existingModule.Version -notcontains $pesterVer)) {
         Install-Module Pester -RequiredVersion $pesterVer -Force -Scope CurrentUser -SkipPublisherCheck

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -3,6 +3,8 @@ $here = Split-Path -Parent $PSCommandPath
 $pesterVer = '4.10.1'
 try {
     # Display what version of Azure PowerShell we have available
+    Write-Host "Checking Az PowerShell module versions..."
+    Get-Module Az -ListAvailable | Format-Table | Out-string | Write-Host
     Get-Module Az.Resources -ListAvailable | Format-Table | Out-string | Write-Host
 
     [array]$existingModule = Get-Module -ListAvailable Pester

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -7,7 +7,7 @@ try {
         Install-Module Pester -RequiredVersion $pesterVer -Force -Scope CurrentUser -SkipPublisherCheck
     }
     Import-Module Pester
-    $results = Invoke-Pester $here/module -PassThru
+    $results = Invoke-Pester $here/module -PassThru -Show Describe,Failed,Summary
 
     if ($results.FailedCount -gt 0) {
         throw ("{0} out of {1} tests failed - check previous logging for more details" -f $results.FailedCount, $results.TotalCount)


### PR DESCRIPTION
This release marks the start of a general migration away from supporting the Azure Graph versions of the Azure PowerShell modules.

Updated Cmdlets:
* `Assert-AzureAdSecurityGroup` - new option to relax strictness on idempotency checks, also no longer requires the azure-cli
* `Assert-AzureAdServicePrincipalForRbac` - updates to support running under least privilege identities, adds support for using service principal or application secrets
* `Connect-Azure` - now supports auto-login when the `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET` environment variables are defined

New Cmdlets:
* `Assert-AzureAdGroupMembership` - handles managing group membership
* `Get-AzureAdDirectoryObject` - searches groups, users and service principals for a matching name or objectId
* `New-Password` - Generates a strong random password and optionally stores it in Key Vault

Also updates the following dependencies in the Docker image:
* Update to PowerShell 7.2.2
* Add .NET 6 SDK
* Upgrade Azure CLI 2.33
* Upgrade Azure PowerShell 7.3.2
* Upgrade Bicep 0.5.6