### PR TITLE
AzureAD-related Fixes

### DIFF
--- a/module/functions/azure/aad/Assert-AzureAdGroupMembership.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdGroupMembership.ps1
@@ -122,14 +122,14 @@ function _getGroupMembers {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory=$true)]
-        [guid] $groupObjectId
+        [guid] $GroupObjectId
     )
 
-    # Workaround current limitation in Azure PowerShell whereby 'Get-AzADGroupMember' does not
-    # return service principal members
+    # May-2022: Workaround a current limitation, whereby service principal group members are not returned by the v1.0 MS Graph API
     # ref: https://docs.microsoft.com/en-us/powershell/azure/troubleshooting?view=azps-7.5.0#get-azadgroupmember-doesnt-return-service-principals 
+    # ref: https://docs.microsoft.com/en-us/graph/api/group-list-members?view=graph-rest-1.0&tabs=http
     
-    Invoke-AzRestMethod -Uri "https://graph.microsoft.com/beta/groups/$($groupObjectId.Guid)/members" |
+    Invoke-AzRestMethod -Uri "https://graph.microsoft.com/beta/groups/$($GroupObjectId.Guid)/members" |
         Select-Object -ExpandProperty Content |
         ConvertFrom-Json |
         Select-Object -ExpandProperty value

--- a/module/functions/azure/aad/Assert-AzureAdSecurityGroup.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdSecurityGroup.ps1
@@ -73,7 +73,7 @@ function Assert-AzureAdSecurityGroup
 
             $ownersToAssignObjectIds | ForEach-Object {
                 if ($_ -notin $existingOwners) {
-                    Write-Warning "Object ID '$_' was specified to be assigned as group owner, but group already exists and the ownership cannot be updated."
+                    Write-Warning "Object ID '$($_.id)' was specified to be assigned as group owner, but group already exists and the ownership cannot be updated."
                 }
             }
         }

--- a/module/functions/azure/aad/Assert-AzureAdSecurityGroup.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdSecurityGroup.ps1
@@ -61,7 +61,7 @@ function Assert-AzureAdSecurityGroup
     $existingGroup = Get-AzADGroup -DisplayName $DisplayName
 
     # Resolve the ObjectId for any specified owners
-    $ownersToAssignObjectIds = $OwnersToAssignOnCreation |
+    [array]$ownersToAssignObjectIds = $OwnersToAssignOnCreation |
                                     Where-Object { $_ } |
                                     ForEach-Object { Get-AzureAdDirectoryObject -Criterion $_ }
 
@@ -69,10 +69,10 @@ function Assert-AzureAdSecurityGroup
         Write-Host "Security group with name $($existingGroup.displayName) already exists."
 
         if ($ownersToAssignObjectIds) {
-            $existingOwners = _getGroupOwners -GroupObjectId $existingGroup.id
+            [array]$existingOwners = _getGroupOwners -GroupObjectId $existingGroup.id
 
             $ownersToAssignObjectIds | ForEach-Object {
-                if ($_ -notin $existingOwners) {
+                if ($_.id -notin $existingOwners) {
                     Write-Warning "Object ID '$($_.id)' was specified to be assigned as group owner, but group already exists and the ownership cannot be updated."
                 }
             }
@@ -165,19 +165,24 @@ function _getGroupOwners {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory=$true)]
-        [string] $GroupObjectId
+        [guid] $GroupObjectId
     )
 
-    $resp = Invoke-AzRestMethod -Uri "https://graph.microsoft.com/v1.0/groups/$GroupObjectId/owners" |
-                Select-Object -ExpandProperty Content |
-                ConvertFrom-Json |
-                Select-Object -ExpandProperty value |
-                Select-Object -ExpandProperty id
+    # May-2022: Workaround a current limitation, whereby service principal group owners are not returned by the v1.0 MS Graph API
+    # ref: https://docs.microsoft.com/en-us/graph/api/group-list-owners?view=graph-rest-1.0&tabs=http
+
+    $resp = Invoke-AzRestMethod -Method GET -Uri "https://graph.microsoft.com/beta/groups/$($GroupObjectId.Guid)/owners" 
 
     if ($resp.StatusCode -ge 400) {
-        $errorMessage = "Failed to lookup existing group owners [ObjectId=$GroupObjectId]: $($resp.Content | ConvertFrom-Json | Select-Object -ExpandProperty error)"
+        $errorMessage = "Failed to lookup existing group owners [ObjectId=$($GroupObjectId.Guid)]: $($resp.Content | ConvertFrom-Json | Select-Object -ExpandProperty error)"
         throw $errorMessage
     }
 
-    return $resp
+    $ownerObjectIds = $resp |
+                        Select-Object -ExpandProperty Content |
+                        ConvertFrom-Json |
+                        Select-Object -ExpandProperty value |
+                        Select-Object -ExpandProperty id
+
+    return $ownerObjectIds
 }

--- a/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.Tests.ps1
@@ -18,11 +18,13 @@ Describe "Assert-AzureServicePrincipalForRbac Tests" {
         id = '00000000-0000-0000-0000-000000000001'
         appId = [guid]::Empty
         displayName = "mock-sp"
+        passwordCredentials = @()
     }
     $mockApp =  @{
         id = '00000000-0000-0000-0000-000000000002'
         appId = [guid]::Empty
         displayName = "mock-sp"
+        passwordCredentials = @()
     }
 
     # Global mocks

--- a/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
+++ b/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
@@ -109,9 +109,9 @@ function Assert-AzureServicePrincipalForRbac
                             $existingSp.id,
                             $existingSp.appId)
 
+        $existingSecret = $null
         if ($useKeyVault) {
             # if using key vault, check whether the specified secret is available and contains the password
-            $existingSecret = $null
             $kvSecret = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $KeyVaultSecretName
             if ($kvSecret) {
                 $existingSecret = $kvSecret.SecretValue |
@@ -157,7 +157,8 @@ function Assert-AzureServicePrincipalForRbac
             [bool] $UseKeyVault
         )
 
-        if ($PSCmdlet.ParameterSetName -eq "Application") {
+        $applicationMode = $PSCmdlet.ParameterSetName -eq "Application"
+        if ($applicationMode) {
             Write-Verbose "Credential will be associated with the App registration"
             $baseUri = "https://graph.microsoft.com/v1.0/applications/$($Application.id)"
             # Check whether we have an existing credential with the same display name
@@ -201,7 +202,7 @@ function Assert-AzureServicePrincipalForRbac
         # Store the credentials in key vault, if required
         if ($UseKeyVault) {
             $appLoginDetails = @{
-                appId = $Application.appId
+                appId = ($applicationMode ? $Application.appId : $ServicePrincipal.appId)
                 password = $newCred.secretText
                 tenant = (Get-AzContext).Tenant.Id
             }

--- a/module/functions/azure/azcli/Assert-AzCliLogin.ps1
+++ b/module/functions/azure/azcli/Assert-AzCliLogin.ps1
@@ -64,8 +64,8 @@ function Assert-AzCliLogin {
             $azCliParams = @(
                 "login"
                 "--service-principal"
-                "-u `"{0}`"" -f $env:AZURE_CLIENT_ID
-                "-p `"{1}`"" -f $env:AZURE_CLIENT_SECRET
+                "-u `"$($env:AZURE_CLIENT_ID)`""
+                "-p `"$($env:AZURE_CLIENT_SECRET)`""
                 "--tenant $AadTenantId"
             )
             if ($TenantOnly) {

--- a/module/functions/azure/azcli/Invoke-AzCli.Tests.ps1
+++ b/module/functions/azure/azcli/Invoke-AzCli.Tests.ps1
@@ -10,25 +10,25 @@ Describe "Invoke-AzCli" {
 
     Mock _EnsureAzureConnection { $true }
 
-    # we can't mock LASTEXITCODE, but this makes sure that any previous
-    # cli tool error doesn't randomly fail our tests
-    $mockExitCodes = @(0,$LASTEXITCODE)
-
     Context "Command parameter type" {
+
+        # ensure the test isn't polluted by any previous CLI tool that has been run in the current session
+        # and that it doesn't fall foul of StrictMode if no tools have been run and $LASTEXITCODE is undefined
+        $LASTEXITCODE = 0
 
         Mock _invokeAzCli {}
         Mock _invokeAzCli {} -ParameterFilter { $CommandLine -eq "az foo bar --query `"[?foo == 'bar']`"" } -Verifiable
 
         It "should execute a string-based command correctly" {
             $cmd = "foo bar --query `"[?foo == 'bar']`""
-            $output,$stdErr = Invoke-AzCli -Command $cmd -ExpectedExitCodes $mockExitCodes
+            $output,$stdErr = Invoke-AzCli -Command $cmd
 
             Assert-VerifiableMock
         }
 
         It "should execute a array-based command correctly" {
             $cmd = @("foo", "bar", "--query `"[?foo == 'bar']`"")
-            $output,$stdErr = Invoke-AzCli -Command $cmd -ExpectedExitCodes $mockExitCodes
+            $output,$stdErr = Invoke-AzCli -Command $cmd
     
             Assert-VerifiableMock
         }
@@ -40,17 +40,17 @@ Describe "Invoke-AzCli" {
 
         It "should throw an exception when the command fails" {
 
-            { $output,$stdErr = Invoke-AzCli -Command $cmd 3>$null } | Should -Throw
+            { $output,$stdErr = Invoke-AzCli -Command $cmd -ErrorAction Stop 3>$null } | Should -Throw
         }
 
-        It "should return error messages written to StdOut and fail" {
-            $output,$stdErr = Invoke-AzCli -Command $cmd -ExpectedExitCodes @(2) 3>$null
+        It "should return error messages written to StdOut" {
+            $output,$stdErr = Invoke-AzCli -Command $cmd -ExpectedExitCodes @("2") -ErrorAction Stop 3>$null
 
             $output | Select-Object -First 1 | Should -Match "'foo' is misspelled or not recognized by the system."
         }
 
         It "should write diagnostic information to the Warning stream" {
-            { $output,$stdErr = Invoke-AzCli -Command $cmd 3>$here/warn-stream.log } | should -Throw
+            { $output,$stdErr = Invoke-AzCli -Command $cmd -ErrorAction Stop 3>$here/warn-stream.log } | should -Throw
             try {
                 Get-Content $here/warn-stream.log | Select-Object -First 1 | Should -Match "azure-cli error diagnostic information:"
             }

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -1,4 +1,5 @@
 $ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
 $here = Split-Path -Parent $PSCommandPath
 $pesterVer = '4.10.1'
 try {


### PR DESCRIPTION
This release fixes some issues identified in the 0.4.0 release.

Updated Cmdlets:
- `Assert-AzureAdSecurityGroup` - Fixes issue with group owners being reported as not up-to-date when they are
- `Assert-AzureServicePrincipalForRbac` - Fixed bug whereby service principal credentials would not be stored in key vault

Also updates some of the Pester tests so they pass when running in `StrictMode`.