### PR TITLE
Add support for resolving deployment config settings via Key Vault secrets

### DIFF
--- a/module/functions/configuration/Read-DeploymentConfig.ps1
+++ b/module/functions/configuration/Read-DeploymentConfig.ps1
@@ -1,4 +1,4 @@
-# <copyright file="Read-DeploymentConfig.Tests.ps1" company="Endjin Limited">
+# <copyright file="Read-DeploymentConfig.ps1" company="Endjin Limited">
 # Copyright (c) Endjin Limited. All rights reserved.
 # </copyright>
 
@@ -27,6 +27,13 @@ The file extension used by files within the deployment configuration repository.
 .PARAMETER RequiredConfigurationKey
 The configuration setting that contains the list of any other required configuration settings.  This is used to
 pre-validate that the loaded deployment configuration has all the required values.
+
+.NOTES
+Configuration values can be literal values or can reference configuration handlers that are responsible for
+resolving the value.  For example, the following syntax can be used to have a configuration value populated
+from an Azure Key Vault Secret:
+
+$myPassword = "@Microsoft.KeyVault(SecretUri=https://myvault.vault.azure.net/secrets/my-password)"
 
 .OUTPUTS
 Hashtable
@@ -75,5 +82,7 @@ function Read-DeploymentConfig
         }
     }
 
-    $deploymentConfig
+    $resolvedDeploymentConfig = _ResolveDeploymentConfigValues $deploymentConfig
+
+    $resolvedDeploymentConfig
 }

--- a/module/functions/configuration/_ResolveDeploymentConfigValues.Tests.ps1
+++ b/module/functions/configuration/_ResolveDeploymentConfigValues.Tests.ps1
@@ -1,0 +1,87 @@
+# <copyright file="_ResolveDeploymentConfigValues.Tests.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".ps1")
+
+. "$here\$sut"
+
+# Import other dependency functions
+. $here/../azure/_EnsureAzureConnection.ps1
+
+Describe "_ResolveDeploymentConfigValues Tests" {
+
+    Context "No resolvable values" {
+
+        $mockConfig = @{
+            foo = "bar"
+            bar = $true
+            foobar = 2
+        }
+
+        $res = _ResolveDeploymentConfigValues $mockConfig
+
+        It "should return unmodified configuration values" {
+            $res | should -be $mockConfig
+        }
+    }
+
+    Context "Key Vault SecretUri Handler" {
+
+        $mockSecretUri = "https://myvault.vault.azure.net/secrets/mysecret"
+        $mockConfig = @{
+            foo = "bar"
+            bar = $true
+            foobar = 2
+            passwd = "@Microsoft.KeyVault(SecretUri=$mockSecretUri)" 
+        }
+
+        Mock _EnsureAzureConnection {}
+        Mock _invokeHandler { "secret-password" }
+        
+        $res = _ResolveDeploymentConfigValues $mockConfig
+
+        It "should call the KeyVaultSecretUri handler" {
+            Assert-MockCalled _invokeHandler -Times 1 -ParameterFilter { $HandlerName -eq "_keyVaultSecretUriHandler" -and $ValueToResolve -eq $mockSecretUri }
+        }
+
+        It "should update the configuration object with the resolved value" {
+            $res.passwd | should -be "secret-password"
+        }
+    }
+}
+
+Describe "_ResolveDeploymentConfigValues Integration Tests" -Tag Integration {
+
+    BeforeAll {
+        $script:testRgName = (New-Guid).Guid
+        $script:testKvName = "x{0}" -f $testRgName.Replace("-","").Substring(0,22)
+        $script:testSecretValue = (New-Guid).Guid
+        $script:testSecretName = "test-secret"
+
+        Write-Host "Provisioning test resources..."
+        New-AzResourceGroup -Name $testRgName -Location UKSouth | Out-Null
+        $kv = New-AzKeyVault -ResourceGroupName $testRgName -Name $testKvName -Location UKSouth
+        $script:kvSecret = Set-AzKeyVaultSecret -VaultName $kv.VaultName -Name $testSecretName -SecretValue (ConvertTo-SecureString $testSecretValue -AsPlainText)
+    }
+    AfterAll {
+        Write-Host "Removing test resources..."
+        Remove-AzResourceGroup -ResourceGroupName $testRgName -Force | Out-Null
+        Remove-AzKeyVault -VaultName $testKvName -Location UKSouth -InRemovedState -Force | Out-Null
+    }
+
+    Context "Key Vault SecretUri Handler" {
+        Mock _EnsureAzureConnection {}
+
+        $mockConfig = @{
+            username = "someuser"
+            password = "@Microsoft.KeyVault(SecretUri=$($kvSecret.Id))" 
+        }
+        
+        $res = _ResolveDeploymentConfigValues $mockConfig
+
+        It "should resolve the correct value from Key Vault" {
+            $mockConfig.password | should -be $testSecretValue
+        }
+    }
+}

--- a/module/functions/configuration/_ResolveDeploymentConfigValues.ps1
+++ b/module/functions/configuration/_ResolveDeploymentConfigValues.ps1
@@ -1,0 +1,62 @@
+# <copyright file="_ResolveDeploymentConfigValues.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+<#
+.SYNOPSIS
+Detects whether any configuration values need to be resolved by a handler.
+
+.DESCRIPTION
+Detects whether any configuration values need to be resolved by a handler.
+
+.PARAMETER DeploymentConfig
+A hashtable containing the configuration key/value pairs.
+
+#>
+function _ResolveDeploymentConfigValues {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [hashtable] $DeploymentConfig
+    )
+
+    for ($i=0; $i -lt $DeploymentConfig.Keys.Count; $i++) {
+        $key = $DeploymentConfig.Keys | Select-Object -Skip $i -First 1
+        Write-Verbose "Checking resolvers for '$key'"
+        $configValue = $DeploymentConfig[$key]
+
+        foreach ($resolver in $configHandlers) {
+            Write-Verbose "Checking resolver: '$($resolver.name)'"
+            $handlerRes = [regex]::Matches($configValue, $resolver.matcher)
+            if ($handlerRes.Count -gt 0) {
+                Write-Verbose "Matched resolver: '$($resolver.name)'"
+                $DeploymentConfig[$key] = _invokeHandler -HandlerName $resolver.handler `
+                                                         -ValueToResolve $handlerRes[0].Groups['valueToResolve'].Value
+                break
+            }
+        }
+    }
+
+    return $DeploymentConfig
+}
+
+
+function _invokeHandler {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [string] $HandlerName,
+        [Parameter(Mandatory=$true)]
+        [string] $ValueToResolve
+    )
+
+    & $HandlerName $ValueToResolve
+}
+
+# Dynamically load the discovered configuration handlers
+$private:here = Split-Path -Parent $PSCommandPath
+$script:configHandlers = @()
+foreach ($handler in (Get-ChildItem $here/handlers/*.ps1)) {
+    . $handler.FullName
+}
+

--- a/module/functions/configuration/handlers/_keyVaultSecretUriHandler.ps1
+++ b/module/functions/configuration/handlers/_keyVaultSecretUriHandler.ps1
@@ -1,0 +1,45 @@
+# <copyright file="_keyVaultSecretUriHandler.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+<#
+.SYNOPSIS
+Implements the handler for resolving Key Vault SecretUri references.
+
+.DESCRIPTION
+Implements the handler for resolving Key Vault SecretUri references.
+
+.PARAMETER ValueToResolve
+The Key Vault Secret URI to be resolved.
+
+#>
+function _keyVaultSecretUriHandler {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true, Position=0)]
+        $ValueToResolve
+    )
+
+    # Check whether we have a valid AzPowerShell connection
+    _EnsureAzureConnection -AzPowerShell -ErrorAction Stop | Out-Null
+
+    if ($ValueToResolve -notmatch "\?api-version=") {
+        $ValueToResolve = "$($ValueToResolve)?api-version=7.3"
+    }
+    $res = Invoke-AzRestMethod -Uri $ValueToResolve
+    if ($res.StatusCode -eq 200) {
+        $res.Content |
+            ConvertFrom-Json | 
+            Select-Object -ExpandProperty value
+    }
+    else {
+        throw "Unable to resolve Key Vault secret: $($res.Content)"
+    }
+}
+
+# Register this handler with _ResolveDeploymentConfigValues
+$script:configHandlers += @{
+    name = "KeyVaultSecretUri"
+    matcher = "@Microsoft.KeyVault\(SecretUri=(?<valueToResolve>.*)\)"
+    handler = "_keyVaultSecretUriHandler"
+}

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -6,8 +6,8 @@ try {
     if (!$existingModule -or ($existingModule.Version -notcontains $pesterVer)) {
         Install-Module Pester -RequiredVersion $pesterVer -Force -Scope CurrentUser -SkipPublisherCheck
     }
-    Import-Module Pester
-    $results = Invoke-Pester $here/module -PassThru -Show Describe,Failed,Summary
+    Import-Module Pester -RequiredVersion $pesterVer
+    $results = Invoke-Pester $here/module -ExcludeTag Integration -PassThru -Show Describe,Failed,Summary
 
     if ($results.FailedCount -gt 0) {
         throw ("{0} out of {1} tests failed - check previous logging for more details" -f $results.FailedCount, $results.TotalCount)


### PR DESCRIPTION
`DeploymentConfig` settings can now use the standard .NET configuration syntax to reference a value stored in Azure Key Vault Secrets:

`@Microsoft.KeyVault(SecretUri=https://<vault-name>.vault.azure.net/secrets/<secret-name>)`
`@Microsoft.KeyVault(SecretUri=https://<vault-name>.vault.azure.net/secrets/<secret-name>/<version-id>)`

For example:
```
@{
  $storageAccountName = "myStorageAccount"
  $storageAccessKey = "@Microsoft.KeyVault(SecretUri=https://myvault.vault.azure.net/secrets/StorageAccessKey)"
}
```

This initial implementation is built on an extensible mechanism for supporting other such external resolution scenarios.