### PR TITLE
Make `Connect-Azure` aware of Managed Identity authentication scenarios

### DIFF
--- a/module/functions/azure/aad/Assert-AzureAdApp.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdApp.ps1
@@ -10,13 +10,19 @@ Ensures that an AzureAD application with the specified configuration exists.
 Ensures that an AzureAD application with the specified configuration exists, creating or updating as necessary.
 
 .PARAMETER DisplayName
-Used to search for an existing AzureAD application or create one with the specified name. Can only be updated for an existing AzureAD application when also updating the 'ReplyUrls' property.
+Used to search for an existing AzureAD application or create one with the specified name.
 
 .PARAMETER IdentifierUri
 The URL to the application homepage. Can only be updated for an existing AzureAD application when also updating the 'ReplyUrls' property.
 
 .PARAMETER ReplyUrls
 The application reply urls. Can be updated for an existing AzureAD application.
+
+.PARAMETER EnableAccessTokenIssuance
+When true, allows the AzureAD application to issue access tokens (used for implicit flow). Can only be updated for an existing AzureAD application when also updating the 'ReplyUrls' property.
+
+.PARAMETER EnableIdTokenIssuance
+When true, allows the AzureAD application to issue ID tokens (used for implicit & hybrid flows). Can only be updated for an existing AzureAD application when also updating the 'ReplyUrls' property.
 
 .OUTPUTS
 Microsoft.Azure.PowerShell.Cmdlets.Resources.MSGraph.Models.ApiV10.MicrosoftGraphApplication
@@ -34,8 +40,38 @@ function Assert-AzureAdApp
         [string] $IdentifierUri,
         
         [Parameter()]
-        [string[]] $ReplyUrls
+        [string[]] $ReplyUrls,
+
+        [Parameter()]
+        [switch] $EnableAccessTokenIssuance,
+
+        [Parameter()]
+        [switch] $EnableIdTokenIssuance
     )
+
+    # Helper functions
+    function _buildAppWebConfig {
+        $webConfigSplat = @{
+            implicitGrantSettings = @{
+                enableAccessTokenIssuance = $EnableAccessTokenIssuance.ToBool()
+                enableIdTokenIssuance = $EnableIdTokenIssuance.ToBool()
+            }
+        }
+        if ($PSBoundParameters.ContainsKey("ReplyUrls")) {
+            $webConfigSplat += @{ redirectUris = $ReplyUrls }
+        }
+        elseif ($app) {
+            $webConfigSplat += @{ redirectUris = $app.Web.redirectUri }
+        }
+        else {
+            $webConfigSplat += @{ redirectUris = @() }
+        }
+        return $webConfigSplat
+    }
+
+   #
+   # Main implementation
+   #
 
     # Check whether we have a valid AzPowerShell connection, but no subscription-level access is required
     _EnsureAzureConnection -AzPowerShell -TenantOnly -ErrorAction Stop | Out-Null
@@ -47,6 +83,7 @@ function Assert-AzureAdApp
     
     if ($app) {
         Write-Host "Found existing app [AppId=$($app.AppId)] [ObjectId=$($app.Id)]"
+        $appNeedsUpdating = $false
         $ReplyUrlsOk = $true
         ForEach ($ReplyUrl in $ReplyUrls) {
             if (!$app.Web.RedirectUri -or !$app.Web.RedirectUri.Contains($ReplyUrl)) {
@@ -55,18 +92,48 @@ function Assert-AzureAdApp
             }
         }
 
-        if (-not $ReplyUrlsOk) {
-            Write-Host "Setting reply URLs: $replyUrls"
-            Update-AzADApplication -ObjectId $app.Id @PSBoundParameters | Out-Null
+        # Check whether 'web' settings need updating
+        if (
+            !$ReplyUrlsOk -or 
+            ($app.Web.ImplicitGrantSetting.EnableAccessTokenIssuance -ne $EnableAccessTokenIssuance) -or 
+            ($app.Web.ImplicitGrantSetting.EnableIdTokenIssuance -ne $EnableIdTokenIssuance)
+        ) {
+            $additionalUpdateParams = @{
+                objectId = $app.Id
+                web = _buildAppWebConfig
+            }
+            $appNeedsUpdating = $true
+        }
+
+        # Check whether other optional settings need to be updated
+        if ($PSBoundParameters.ContainsKey("IdentifierUri") -and $app.IdentifierUri -ne $IdentifierUri) {
+            $appNeedsUpdating = $true
+        }
+
+        if ($appNeedsUpdating) {
+            Write-Host "Updating app"
+            # Remove parameters that cannot be 'splatted' into Update-AzADApplication
+            $PSBoundParameters.Remove("ReplyUrls") | Out-Null
+            $PSBoundParameters.Remove("EnableAccessTokenIssuance") | Out-Null
+            $PSBoundParameters.Remove("EnableIdTokenIssuance") | Out-Null
+
+            Write-Verbose "PSBoundParameters:`n$($PSBoundParameters | ConvertTo-Json -Depth 100)"
+            Write-Verbose "additionalUpdateParams:`n$($additionalUpdateParams | ConvertTo-Json -Depth 100)"
+            Update-AzADApplication @PSBoundParameters @additionalUpdateParams | Out-Null
             $app = Get-AzADApplication -ObjectId $app.Id
         }
     } else {
         Write-Host "Creating new app"
-        $PSBoundParameters.Remove("ReplyUrls") | Out-Null
         $additionalCreateParams = @{}
         if ($ReplyUrls.Count -gt 0) {
-            $additionalCreateParams += @{ web = @{ redirectUris = $ReplyUrls } }
+            $additionalCreateParams += @{
+                web = _buildAppWebConfig
+            }
         }
+        # Remove parameters that cannot be 'splatted' into New-AzADApplication
+        $PSBoundParameters.Remove("ReplyUrls") | Out-Null
+        $PSBoundParameters.Remove("EnableAccessTokenIssuance") | Out-Null
+        $PSBoundParameters.Remove("EnableIdTokenIssuance") | Out-Null
         Write-Verbose "PSBoundParameters:`n$($PSBoundParameters | ConvertTo-Json -Depth 100)"
         Write-Verbose "additionalCreateParams:`n$($createParams | ConvertTo-Json -Depth 100)"
 

--- a/module/functions/azure/aad/Assert-RequiredResourceAccessContains.ps1
+++ b/module/functions/azure/aad/Assert-RequiredResourceAccessContains.ps1
@@ -37,6 +37,9 @@ function Assert-RequiredResourceAccessContains
         [hashtable[]] $AccessRequirements
     )
 
+    # Check whether we have a valid AzPowerShell connection, but no subscription-level access is required
+    _EnsureAzureConnection -AzPowerShell -TenantOnly -ErrorAction Stop | Out-Null
+
     $madeChange = $false
     [array]$requiredResourceAccess = $App.requiredResourceAccess
     $resourceEntry = $requiredResourceAccess | Where-Object { $_.resourceAppId -eq $ResourceAppId }

--- a/module/functions/azure/aad/Get-MicrosoftGraphApiAppUri.ps1
+++ b/module/functions/azure/aad/Get-MicrosoftGraphApiAppUri.ps1
@@ -20,11 +20,11 @@ function Get-MicrosoftGraphApiAppUri
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory=$true)]
-        [Microsoft.Azure.Commands.ActiveDirectory.PSADApplication] $App
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [Microsoft.Azure.PowerShell.Cmdlets.Resources.MSGraph.Models.ApiV10.MicrosoftGraphApplication] $App
     )
 
-    $graphApiAppUri = ("https://graph.microsoft.com/v1.0/{0}/applications/{1}" -f $script:moduleContext.AadTenantId, $App.ObjectId)
+    $graphApiAppUri = ("https://graph.microsoft.com/v1.0/{0}/applications/{1}" -f $script:moduleContext.AadTenantId, $App.Id)
 
     return $graphApiAppUri
 }


### PR DESCRIPTION
Updated Cmdlets:
- `Connect-Azure` - Ensure the authentication logic understands the environment variable conventions typically used for managed identity scenarios
- `Assert-AzureAdApp` - Updated to support only versions of Azure PowerShell post the Microsoft Graph migration
- `Assert-RequiredResourceAccessContains` - Updated to support only versions of Azure PowerShell post the Microsoft Graph migration

Closes #82
Closes #83 