### PR TITLE
Fixed null return value in `Assert-RequiredResourceAccessContains`

### DIFF
--- a/module/functions/azure/aad/Assert-RequiredResourceAccessContains.ps1
+++ b/module/functions/azure/aad/Assert-RequiredResourceAccessContains.ps1
@@ -81,7 +81,7 @@ function Assert-RequiredResourceAccessContains
         }
         
         $App = Get-AzADApplication -ObjectId $App.Id
-
-        return $App
     }
+
+    return $App
 }


### PR DESCRIPTION
Ensures the AAD App Registration details are always returned, even when unchanged by this cmdlet.

Resolves #84 