### PR TITLE
Migrate `Assert-AzureAdAppRole` to only use MSGraph

### DIFF
--- a/module/functions/azure/aad/Assert-AzureAdAppRole.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdAppRole.Tests.ps1
@@ -34,7 +34,7 @@ Describe "Assert-AzureAdAppRole Tests" {
 
     Context "When no application roles are defined" {
 
-        Mock Write-Host {} -ParameterFilter { $Object.StartsWith("Adding") }
+        Mock Write-Host {} -ParameterFilter { $Object.EndsWith("CREATING") }
         Mock Update-AzADApplication {} -ParameterFilter { $ObjectId -eq $mockAppObjectId -and $AppRole[0].allowedMemberType -eq $mockAppRole.allowedMemberType }
         Mock Get-AzADApplication {
             @{
@@ -56,7 +56,7 @@ Describe "Assert-AzureAdAppRole Tests" {
     }
 
     Context "When another application role is already defined" {
-        Mock Write-Host {} -ParameterFilter { $Object.StartsWith("Adding") }
+        Mock Write-Host {} -ParameterFilter { $Object.EndsWith("CREATING") }
         Mock Update-AzADApplication {} -ParameterFilter { $ObjectId -eq $mockAppObjectId -and $AppRole[1].allowedMemberType -eq $mockAppRole.allowedMemberType }
         Mock Get-AzADApplication {
             @{
@@ -90,7 +90,7 @@ Describe "Assert-AzureAdAppRole Tests" {
 
         $updatedDescription = "Modified Test App Role"
 
-        Mock Write-Host {} -ParameterFilter { $Object.StartsWith("Updating") }
+        Mock Write-Host {} -ParameterFilter { $Object.EndsWith("UPDATING") }
         Mock Update-AzADApplication {} -ParameterFilter { $ObjectId -eq $mockAppObjectId -and $AppRole[0].description -eq $updatedDescription }
         Mock Get-AzADApplication {
             @{
@@ -113,7 +113,7 @@ Describe "Assert-AzureAdAppRole Tests" {
 
     Context "When an existing application role is up-to-date" {
 
-        Mock Write-Host {} -ParameterFilter { $Object.StartsWith("App role") }
+        Mock Write-Host {} -ParameterFilter { $Object.EndsWith("NO CHANGES") }
         Mock Update-AzADApplication {} -ParameterFilter { $ObjectId -eq $mockAppObjectId -and $AppRole[0].description -eq $updatedDescription }
         Mock Get-AzADApplication {
             @{

--- a/module/functions/azure/aad/Assert-AzureAdAppRole.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdAppRole.Tests.ps1
@@ -1,0 +1,111 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.ps1", ".ps1")
+
+. "$here\$sut"
+
+# define other functions that will be mocked
+function _EnsureAzureConnection {}
+function Get-AzADApplication {}
+function Update-AzADApplication { param([string] $ObjectId, [array] $AppRole)}
+
+Describe "Assert-AzureAdAppRole Tests" {
+
+    $mockAppObjectId = "00000000-0000-0000-0000-000000000000"
+    $mockAppId = "11111111-1111-1111-1111-111111111111"
+
+    $mockAppRole = @{
+        displayName = "Test App Role"
+        id = New-Guid | Select-Object -ExpandProperty Guid
+        isEnabled = $true
+        description = "A Test App Role"
+        value = "TestRole"
+        allowedMemberTypes = @("User")
+    }
+
+    $commonParams = @{
+        AppObjectId = $mockAppObjectId
+        AppRoleId = $mockAppRole.id
+        DisplayName = $mockAppRole.displayName
+        Value = $mockAppRole.value
+        AllowedMemberTypes = @("User")
+    }
+
+    Context "Adding a first application role" {
+
+        Mock Write-Host {} -ParameterFilter { $Object.StartsWith("Adding") }
+        Mock Update-AzADApplication {} -ParameterFilter { $ObjectId -eq $mockAppObjectId -and $AppRole[0].allowedMemberTypes -eq $mockAppRole.allowedMemberTypes }
+        Mock Get-AzADApplication {
+            @{
+                Id = $mockAppObjectId
+                AppId = $mockAppId
+                AppRoles = @()
+            }
+        }
+
+        $res = Assert-AzureAdAppRole `
+                    -Description $mockAppRole.description `
+                    @commonParams
+
+        It "should add the new application role" {
+            Assert-MockCalled Get-AzADApplication -Times 2
+            Assert-MockCalled Update-AzADApplication -Times 1
+            Assert-MockCalled Write-Host -Times 1       # asserts the 'add' code path
+        }
+    }
+
+    Context "Adding an additional application role" {
+        Mock Write-Host {} -ParameterFilter { $Object.StartsWith("Adding") }
+        Mock Update-AzADApplication {} -ParameterFilter { $ObjectId -eq $mockAppObjectId -and $AppRole[1].allowedMemberTypes -eq $mockAppRole.allowedMemberTypes }
+        Mock Get-AzADApplication {
+            @{
+                Id = $mockAppObjectId
+                AppId = $mockAppId
+                AppRoles = @(
+                    @{
+                        displayName = "Existing App Role"
+                        id = New-Guid | Select-Object -ExpandProperty Guid
+                        isEnabled = $true
+                        description = "An Existing App Role"
+                        value = "ExistingAppRole"
+                        allowedMemberTypes = @("Application")
+                    }
+                )
+            }
+        }
+
+        $res = Assert-AzureAdAppRole `
+                    -Description $mockAppRole.description `
+                    @commonParams
+
+        It "should add the new application role" {
+            Assert-MockCalled Get-AzADApplication -Times 2
+            Assert-MockCalled Update-AzADApplication -Times 1
+            Assert-MockCalled Write-Host -Times 1       # asserts the 'add' code path
+        }
+    } 
+
+    Context "Update an existing application role" {
+
+        $updatedDescription = "Modified Test App Role"
+
+        Mock Write-Host {} -ParameterFilter { $Object.StartsWith("Updating") }
+        Mock Update-AzADApplication {} -ParameterFilter { $ObjectId -eq $mockAppObjectId -and $AppRole[0].description -eq $updatedDescription }
+        Mock Get-AzADApplication {
+            @{
+                Id = $mockAppObjectId
+                AppId = $mockAppId
+                AppRoles = @($mockAppRole)
+            }
+        }
+
+        $res = Assert-AzureAdAppRole `
+                    -Description $updatedDescription `
+                    @commonParams
+
+        It "should update the new application role" {
+            Assert-MockCalled Get-AzADApplication -Times 2
+            Assert-MockCalled Update-AzADApplication -Times 1
+            Assert-MockCalled Write-Host -Times 1       # asserts the 'update' code path
+        }
+    }
+}

--- a/module/functions/azure/aad/Assert-AzureAdAppRole.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdAppRole.ps1
@@ -27,6 +27,9 @@ The value for the application role.
 .PARAMETER AllowedMemberTypes
 Allowed member types for the application (User / Application)
 
+.PARAMETER Enabled
+When true, the application is enabled for use otherwise it will not be usable.
+
 .OUTPUTS
 Microsoft.Azure.PowerShell.Cmdlets.Resources.MSGraph.Models.ApiV10.MicrosoftGraphApplication
 #>

--- a/module/functions/azure/aad/Assert-AzureAdAppRole.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdAppRole.ps1
@@ -81,7 +81,7 @@ function Assert-AzureAdAppRole
                                         -DifferenceObject $appRoleFromParams `
                                         -Property ([array]$appRoleFromParams.Keys)
         if ($compareResult) {
-            Write-Host "Updating '$Value' app role"
+            Write-Host "AppRole '$Value': UPDATING"
             $appRole.displayName = $DisplayName
             $appRole.isEnabled = $Enabled
             $appRole.description = $Description
@@ -89,12 +89,12 @@ function Assert-AzureAdAppRole
             $appRole.allowedMemberType = $AllowedMemberTypes
         }
         else {
-            Write-Host "App role '$Value' is up-to-date"
+            Write-Host "AppRole '$Value': NO CHANGES"
             $doUpdate = $false
         }
     }
     else {
-        Write-Host "Adding '$Value' app role"
+        Write-Host "AppRole '$Value': CREATING"
         $appRole = New-Object -TypeName "Microsoft.Azure.PowerShell.Cmdlets.Resources.MSGraph.Models.ApiV10.MicrosoftGraphAppRole" `
                         -Property @{
                             displayName = $DisplayName

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -8,6 +8,14 @@ try {
         Install-Module Pester -RequiredVersion $pesterVer -Force -Scope CurrentUser -SkipPublisherCheck
     }
     Import-Module Pester -RequiredVersion $pesterVer
+
+    # Install other modules required by the tests
+    $latestExistingAzResourcesModule = Get-Module -ListAvailable Az.Resources | Select -ExpandProperty Version | Sort -Descending | Select -First 1
+    if (!$latestExistingAzResourcesModule -or $latestExistingAzResourcesModule -lt "6.5.3") {
+        Write-Host "Installing module: Az.Resources ..."
+        Install-Module Az.Resources -MinimumVersion "6.5.3" -Force -Scope CurrentUser
+    }
+
     $results = Invoke-Pester $here/module `
                          -ExcludeTag Integration `
                          -PassThru `

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -10,7 +10,7 @@ try {
     Import-Module Pester -RequiredVersion $pesterVer
 
     # Install other modules required by the tests
-    $latestExistingAzResourcesModule = Get-Module -ListAvailable Az.Resources | Select -ExpandProperty Version | Sort -Descending | Select -First 1
+    $latestExistingAzResourcesModule = Get-Module -ListAvailable Az.Resources | Select-Object -ExpandProperty Version | Sort-Object -Descending | Select-Object -First 1
     if (!$latestExistingAzResourcesModule -or $latestExistingAzResourcesModule -lt "6.5.3") {
         Write-Host "Installing module: Az.Resources ..."
         Install-Module Az.Resources -MinimumVersion "6.5.3" -Force -Scope CurrentUser


### PR DESCRIPTION
- Updates the cmdlet to align with the wider strategy to only support MS Graph
- Improves checks to ensure `AppRoles` are not unnecessarily updated
- Adds some Pester test coverage

Closes #87 