### PR TITLE
Fix issue with `Invoke-AzRestMethod` requests failing silently

### DIFF
--- a/module/functions/azure/_HandleRestError.ps1
+++ b/module/functions/azure/_HandleRestError.ps1
@@ -19,7 +19,7 @@ function _HandleRestError
     [CmdletBinding()]
     param (
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
-        [PSHttpResponse] $Response
+        [Microsoft.Azure.Commands.Profile.Models.PSHttpResponse] $Response
     )
 
     # NOTE: 

--- a/module/functions/azure/_HandleRestError.ps1
+++ b/module/functions/azure/_HandleRestError.ps1
@@ -1,0 +1,35 @@
+# <copyright file="_HandleRestError.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+<#
+.SYNOPSIS
+Checks the HTTP response object returned by 'Invoke-AzRestMethod' for errors.
+
+.DESCRIPTION
+Checks the HTTP response object returned by 'Invoke-AzRestMethod' for errors.
+
+.PARAMETER Response
+The response object return by 'Invoke-AzRestMethod'.
+
+#>
+
+function _HandleRestError
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [PSHttpResponse] $Response
+    )
+
+    # NOTE: 
+    #       _EnsureAzureConnection
+    #       Suppress 'validate the Azure connection' test.
+    #       The inclusion of 'Invoke-AzRestMethod' in the comments above cause a false positive.
+
+    if ($Response.StatusCode -ge 400) {
+        throw ($Response.Content | ConvertFrom-Json -Depth 100).error | ConvertTo-Json -Depth 100
+    }
+
+    return $Response
+}

--- a/module/functions/azure/aad/Assert-AzureAdGroupMembership.ps1
+++ b/module/functions/azure/aad/Assert-AzureAdGroupMembership.ps1
@@ -130,6 +130,7 @@ function _getGroupMembers {
     # ref: https://docs.microsoft.com/en-us/graph/api/group-list-members?view=graph-rest-1.0&tabs=http
     
     Invoke-AzRestMethod -Uri "https://graph.microsoft.com/beta/groups/$($GroupObjectId.Guid)/members" |
+        _HandleRestError |
         Select-Object -ExpandProperty Content |
         ConvertFrom-Json |
         Select-Object -ExpandProperty value

--- a/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.Tests.ps1
@@ -9,6 +9,7 @@ function Set-AzKeyVaultSecret {}
 function Get-AzContext {}
 function Invoke-AzRestMethod { param($Uri, $Method, $Payload) }
 function _EnsureAzureConnection {}
+function _HandleRestError { param([Parameter(ValueFromPipeline=$true)]$Response) return $Response }
 function Write-Host {}
 
 Describe "Assert-AzureServicePrincipalForRbac Tests" {

--- a/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
+++ b/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
@@ -180,7 +180,7 @@ function Assert-AzureServicePrincipalForRbac
             Write-Host "Removing existing credential [DisplayName=$CredentialDisplayName; KeyId=$($existingCred.keyId)]"
             $resp = Invoke-AzRestMethod -Uri "$baseUri/removePassword" `
                                         -Method POST `
-                                        -Payload ( @{keyId = $existingCred.keyId} | ConvertTo-Json -Compress )
+                                        -Payload ( @{keyId = $existingCred.keyId} | ConvertTo-Json -Compress ) | _HandleRestError
         }   
 
         # Now we can generate the new credential - we use the REST API rather than a build cmdlet so that
@@ -194,7 +194,7 @@ function Assert-AzureServicePrincipalForRbac
         }
         $resp = Invoke-AzRestMethod -Uri "$baseUri/addPassword" `
                                     -Method POST `
-                                    -Payload ($body | ConvertTo-Json -Compress)
+                                    -Payload ($body | ConvertTo-Json -Compress) | _HandleRestError
         $newCred = $resp.Content |
                         ConvertFrom-Json -AsHashtable
         
@@ -226,7 +226,7 @@ function Assert-AzureServicePrincipalForRbac
             $DisplayName
         )
 
-        $resp = Invoke-AzRestMethod -Uri "https://graph.microsoft.com/v1.0/applications?`$filter=displayName eq '$DisplayName'"
+        $resp = Invoke-AzRestMethod -Uri "https://graph.microsoft.com/v1.0/applications?`$filter=displayName eq '$DisplayName'" | _HandleRestError
         $app = $resp.Content |
                     ConvertFrom-Json -AsHashtable -Depth 100 |
                     Select-Object -ExpandProperty value
@@ -244,7 +244,7 @@ function Assert-AzureServicePrincipalForRbac
         Write-Verbose "Creating app registation object [DisplayName=$DisplayName]"
         $resp = Invoke-AzRestMethod -Uri "https://graph.microsoft.com/v1.0/applications" `
                                     -Method POST `
-                                    -Payload ($payload | ConvertTo-Json)
+                                    -Payload ($payload | ConvertTo-Json) | _HandleRestError
         $newApp = $resp.Content |
                     ConvertFrom-Json -AsHashtable
         Write-Verbose "Created app registation object [AppId=$($newApp.appId); Id=$($newApp.id)]"
@@ -258,7 +258,7 @@ function Assert-AzureServicePrincipalForRbac
             $DisplayName
         )
 
-        $resp = Invoke-AzRestMethod -Uri "https://graph.microsoft.com/v1.0/servicePrincipals?`$filter=displayName eq '$DisplayName'"
+        $resp = Invoke-AzRestMethod -Uri "https://graph.microsoft.com/v1.0/servicePrincipals?`$filter=displayName eq '$DisplayName'" | _HandleRestError
         $sp = $resp.Content |
                     ConvertFrom-Json -AsHashtable -Depth 100 |
                     Select-Object -ExpandProperty value
@@ -284,7 +284,7 @@ function Assert-AzureServicePrincipalForRbac
         Write-Verbose "Creating service principal object [AppId=$($app.appId)]"
         $resp = Invoke-AzRestMethod -Uri "https://graph.microsoft.com/v1.0/servicePrincipals" `
                                      -Method POST `
-                                     -Payload ($payload | ConvertTo-Json)
+                                     -Payload ($payload | ConvertTo-Json) | _HandleRestError
         $newSp = $resp.Content |
                     ConvertFrom-Json -AsHashtable
         Write-Verbose "Created service principal object [Id=$($newSp.id)]"

--- a/module/functions/azure/aad/Assert-RequiredResourceAccessContains.ps1
+++ b/module/functions/azure/aad/Assert-RequiredResourceAccessContains.ps1
@@ -75,10 +75,7 @@ function Assert-RequiredResourceAccessContains
         $resp = Invoke-AzRestMethod `
                     -Uri $uri `
                     -Method PATCH `
-                    -Payload ($body | ConvertTo-Json -Depth 100 -Compress)
-        if ($resp.StatusCode -ge 400) {
-            throw $resp.Content
-        }
+                    -Payload ($body | ConvertTo-Json -Depth 100 -Compress) | _HandleRestError
         
         $App = Get-AzADApplication -ObjectId $App.Id
     }


### PR DESCRIPTION
Updated Cmdlets:

- `Assert-AzureAdGroupMembership`
- `Assert-AzureServicePrincipalForRbac`
- `Assert-RequiredResourceAccessContains`

Also adds an internal helper function to handle this error checking.
