### PR TITLE
Fix `Assert-AzureServicePrincipalForRbac`

### DIFF
--- a/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.Tests.ps1
@@ -524,5 +524,101 @@ Describe "Assert-AzureServicePrincipalForRbac Tests" {
                 }
             }
         }
+
+        Context "Kay Vault secret validation" {
+                
+            Describe "Existing secret storing the 'clientSecret' property without 'RotateSecret' option" {
+                $mockSavedSecret = @{
+                    appId = "mockAppId"
+                    clientSecret = "mockSecret"
+                    tenantId = "mockTenantId"
+                }
+                Mock Get-AzKeyVaultSecret { @{ SecretValue = ($mockSavedSecret | ConvertTo-Json | ConvertTo-SecureString -AsPlainText) } }
+
+                Mock _getServicePrincipal { $mockSp }
+                Mock _getApplication { $mockApp }
+
+                Mock _newApplication {}
+                Mock _newServicePrincipal {}
+
+                $res = Assert-AzureServicePrincipalForRbac `
+                            -Name "mock-sp" `
+                            -CredentialDisplayName "mock-credential" `
+                            -KeyVaultName "mock-keyvault" `
+                            -KeyVaultSecretName "mock-secret-name"
+
+                It "should not create a new service principal" {
+                    Assert-MockCalled _newApplication -Times 0
+                    Assert-MockCalled _newServicePrincipal -Times 0
+                }
+
+                It "should check for an existing secret in the key vault" {
+                    Assert-MockCalled Get-AzKeyVaultSecret -Times 1     # the SP exists so we should check the key vault
+                }
+
+                It "should not create a new service principal credential" {
+                    $res.Count | Should -Be 2
+                    $res[0].id | Should -Be '00000000-0000-0000-0000-000000000001'
+                    $res[1] | Should -Be $null
+
+                    Assert-MockCalled _getServicePrincipal -Times 1
+                    Assert-MockCalled _getApplication -Times 0
+                    Assert-MockCalled Invoke-AzRestMethod -Times 0 -ParameterFilter { $Uri.EndsWith("addPassword") -and $Uri -match "servicePrincipals" }
+                    Assert-MockCalled Invoke-AzRestMethod -Times 0 -ParameterFilter { $Uri.EndsWith("addPassword") -and $Uri -match "applications" }
+                }
+
+                It "should not update the key vault secret" {
+                    Assert-MockCalled Set-AzKeyVaultSecret -Times 0     # the key vault should be updated with new secret
+                }
+            }
+            Describe "Existing invalid secret in key vault without 'RotateSecret' option" {
+                $mockSavedSecret = @{
+                    appId = "mockAppId"
+                    tenantId = "mockTenantId"
+                }
+                Mock Get-AzKeyVaultSecret { @{ SecretValue = ($mockSavedSecret | ConvertTo-Json | ConvertTo-SecureString -AsPlainText) } }
+                Mock Write-Warning {}
+                
+                Mock _getServicePrincipal { $mockSp }
+                Mock _getApplication { $mockApp }
+
+                Mock _newApplication {}
+                Mock _newServicePrincipal {}
+
+                $res = Assert-AzureServicePrincipalForRbac `
+                            -Name "mock-sp" `
+                            -CredentialDisplayName "mock-credential" `
+                            -KeyVaultName "mock-keyvault" `
+                            -KeyVaultSecretName "mock-secret-name"
+
+                It "should not create a new service principal" {
+                    Assert-MockCalled _newApplication -Times 0
+                    Assert-MockCalled _newServicePrincipal -Times 0
+                }
+
+                It "should check for an existing secret in the key vault" {
+                    Assert-MockCalled Get-AzKeyVaultSecret -Times 1     # the SP exists so we should check the key vault
+                }
+
+                It "should log a warning message" {
+                    Assert-MockCalled Write-Warning -Time 1
+                }
+
+                It "should create a new service principal credential" {
+                    $res.Count | Should -Be 2
+                    $res[0].id | Should -Be '00000000-0000-0000-0000-000000000001'
+                    $res[1] | Should -Be $null
+
+                    Assert-MockCalled _getServicePrincipal -Times 1
+                    Assert-MockCalled _getApplication -Times 0
+                    Assert-MockCalled Invoke-AzRestMethod -Times 1 -ParameterFilter { $Uri.EndsWith("addPassword") -and $Uri -match "servicePrincipals" }
+                    Assert-MockCalled Invoke-AzRestMethod -Times 0 -ParameterFilter { $Uri.EndsWith("addPassword") -and $Uri -match "applications" }
+                }
+
+                It "should update the key vault secret" {
+                    Assert-MockCalled Set-AzKeyVaultSecret -Times 1     # the key vault should be updated with new secret
+                }
+            }
+        }
     }
 }

--- a/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.Tests.ps1
+++ b/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.Tests.ps1
@@ -275,8 +275,8 @@ Describe "Assert-AzureServicePrincipalForRbac Tests" {
     Context "Key Vault Support" {
 
         $mockSavedSecret = @{
-            appId = "mockAppId"
-            password = "mockSecret"
+            clientId = "mockAppId"
+            clientSecret = "mockSecret"
             tenantId = "mockTenantId"
         }
         Mock Get-AzKeyVaultSecret { @{ SecretValue = ($mockSavedSecret | ConvertTo-Json | ConvertTo-SecureString -AsPlainText) } }
@@ -529,7 +529,7 @@ Describe "Assert-AzureServicePrincipalForRbac Tests" {
                 
             Describe "Existing secret storing the 'clientSecret' property without 'RotateSecret' option" {
                 $mockSavedSecret = @{
-                    appId = "mockAppId"
+                    clientId = "mockAppId"
                     clientSecret = "mockSecret"
                     tenantId = "mockTenantId"
                 }
@@ -573,7 +573,7 @@ Describe "Assert-AzureServicePrincipalForRbac Tests" {
             }
             Describe "Existing invalid secret in key vault without 'RotateSecret' option" {
                 $mockSavedSecret = @{
-                    appId = "mockAppId"
+                    clientId = "mockAppId"
                     tenantId = "mockTenantId"
                 }
                 Mock Get-AzKeyVaultSecret { @{ SecretValue = ($mockSavedSecret | ConvertTo-Json | ConvertTo-SecureString -AsPlainText) } }

--- a/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
+++ b/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
@@ -135,7 +135,7 @@ function Assert-AzureServicePrincipalForRbac
         # rotate the client secret/credential 
         if (($useKeyVault -and $kvSecretIsMissingOrInvalid) -or $RotateSecret) {
             if ($PSCmdlet.ShouldProcess($Name, "Rotate Service Principal Secret")) {
-                Write-Host "Rotating service principal credential [UseKeyVault=$useKeyVault, KeyVaultSecretMissing=$(!$existingSecret), RotateFlag=$RotateSecret]"
+                Write-Host "Rotating service principal credential [UseKeyVault=$useKeyVault, KeyVaultSecretMissingOrInvalid=$($kvSecretIsMissingOrInvalid), RotateFlag=$RotateSecret]"
                 if ($UseApplicationCredential) {
                     $app = _getApplicationForNewAppCredential -DisplayName $Name
                     Write-Host "Credential will be added to app registration [AppId=$($app.appId)]"

--- a/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
+++ b/module/functions/azure/aad/Assert-AzureServicePrincipalForRbac.ps1
@@ -212,6 +212,11 @@ function Assert-AzureServicePrincipalForRbac
 
         # Store the credentials in key vault, if required
         if ($UseKeyVault) {
+            # This format of secret is compatible with 'azure/login' GitHub Action, whilst the 'password'
+            # property has been changed to 'clientSecret' in the later documentation, the original property
+            # name still works.  Also, the Azure CLI still produces the 'password' property in the output of its
+            # 'az ad sp create-for-rbac' command, so for now we will stick with this format.
+            # REF: https://github.com/azure/login?tab=readme-ov-file#creds
             $appLoginDetails = @{
                 appId = ($applicationMode ? $Application.appId : $ServicePrincipal.appId)
                 password = $newCred.secretText


### PR DESCRIPTION
Resolves an issue where this cmdlet was not handling the more recent property names used to hold the credential details.

Originally they were `appId`, `password` & `tenant`; this has since changed to `clientId`, `clientSecret`, `tenantId`.

The cmdlet will now detect when an existing KV secret is using the old format and will force a secret rotation in order to update the structure.

Also adds some test coverage for this new logic.