### PR TITLE
Refactor `_ResolveDeploymentConfigValues` to use an array for keys to prevent enumeration issues

### DIFF
--- a/module/functions/configuration/_ResolveDeploymentConfigValues.ps1
+++ b/module/functions/configuration/_ResolveDeploymentConfigValues.ps1
@@ -20,8 +20,10 @@ function _ResolveDeploymentConfigValues {
         [hashtable] $DeploymentConfig
     )
 
-    for ($i=0; $i -lt $DeploymentConfig.Keys.Count; $i++) {
-        $key = $DeploymentConfig.Keys | Select-Object -Skip $i -First 1
+    # Capture keys to an array to avoid enumeration issues when modifying the hashtable
+    $keys = @($DeploymentConfig.Keys)
+    
+    foreach ($key in $keys) {
         Write-Verbose "Checking resolvers for '$key'"
         $configValue = $DeploymentConfig[$key]
 


### PR DESCRIPTION
Previously we were seeing config settings being skipped over, and therefore were not resolved correctly.